### PR TITLE
Android feed: fresh-clone build, stale profiles, and per-row profile invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *.bak2
 /HavenApp/build
 /HavenApp/build_data
-*.txt
+# Root-level scratch notes only. A blanket *.txt swallowed
+# NostrVault/app/src/main/CMakeLists.txt, which app/build.gradle.kts
+# requires, so a fresh clone could not assemble the Android APK.
+/*.txt
 /build
 /build_data
 *.build

--- a/NostrVault/app/build.gradle.kts
+++ b/NostrVault/app/build.gradle.kts
@@ -18,12 +18,22 @@ android {
     namespace = "com.nostrvault"
     compileSdk = 35
 
+    // Only wire the release signer when local.properties actually carries the
+    // keystore. The unconditional `as String` casts here threw at configuration
+    // time on any checkout without it, which failed even `compileDebugKotlin` —
+    // a debug build has no business needing the release keystore.
+    val hasReleaseKeystore = listOf(
+        "KEYSTORE_PATH", "KEYSTORE_PASSWORD", "KEY_ALIAS", "KEY_PASSWORD",
+    ).all { localProps[it] != null }
+
     signingConfigs {
-        create("release") {
-            storeFile = file(localProps["KEYSTORE_PATH"] as String)
-            storePassword = localProps["KEYSTORE_PASSWORD"] as String
-            keyAlias = localProps["KEY_ALIAS"] as String
-            keyPassword = localProps["KEY_PASSWORD"] as String
+        if (hasReleaseKeystore) {
+            create("release") {
+                storeFile = file(localProps["KEYSTORE_PATH"] as String)
+                storePassword = localProps["KEYSTORE_PASSWORD"] as String
+                keyAlias = localProps["KEY_ALIAS"] as String
+                keyPassword = localProps["KEY_PASSWORD"] as String
+            }
         }
     }
 
@@ -49,7 +59,9 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
-            signingConfig = signingConfigs.getByName("release")
+            // Unsigned without a keystore; `assembleRelease` then produces an
+            // unsigned APK instead of failing the whole configuration phase.
+            if (hasReleaseKeystore) signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/NostrVault/app/src/main/CMakeLists.txt
+++ b/NostrVault/app/src/main/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22.1)
+project("nostrvault-jni")
+
+# Build the JNI bridge that connects Kotlin -> Go C exports
+add_library(
+    nostrvault-jni
+    SHARED
+    java/com/nostrvault/relay/HavenBridgeJNI.c
+)
+
+# Link against the pre-built Go relay .so
+add_library(haven SHARED IMPORTED)
+set_target_properties(haven PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/jniLibs/${ANDROID_ABI}/libhaven.so
+    IMPORTED_NO_SONAME TRUE
+)
+
+# Link JNI bridge against Go library and Android log
+target_link_libraries(
+    nostrvault-jni
+    haven
+    log
+)

--- a/NostrVault/app/src/main/java/com/nostrvault/service/ProfilePicturePrefetcher.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/service/ProfilePicturePrefetcher.kt
@@ -44,6 +44,8 @@ class ProfilePicturePrefetcher @Inject constructor(
         private const val DEBOUNCE_MS = 12L * 60 * 60 * 1000 // 12 hours
         private const val STARTUP_DELAY_MS = 10_000L // Wait for contacts to load
         private const val PROFILE_FETCH_WAIT_MS = 5_000L // Wait for Kind 0 metadata
+        private const val METADATA_CHUNK_SIZE = 100 // Follows per metadata REQ
+        private const val METADATA_CHUNK_DELAY_MS = 750L // Breathing room between them
         private const val PREFS_NAME = "avatar_prefetch"
         private const val PREF_LAST_RUN = "last_run_timestamp"
     }
@@ -127,12 +129,19 @@ class ProfilePicturePrefetcher @Inject constructor(
 
             Log.d(TAG, "Starting avatar prefetch for ${pubkeys.size} followed accounts")
 
-            // Fetch missing profile metadata first
+            // Fetch missing profile metadata first, paced. Handing the whole
+            // follow list over at once became a single metadata REQ for every
+            // follow, and the kind-0 flood it answered with landed on the feed
+            // while the user was scrolling it. Chunking spreads that over the
+            // sweep instead; the avatars are wanted eventually, not this second.
             val profiles = nostrService.profiles.value
             val missingProfiles = pubkeys.filter { profiles[it] == null }
             if (missingProfiles.isNotEmpty()) {
                 Log.d(TAG, "Fetching ${missingProfiles.size} missing profiles")
-                nostrService.fetchMissingProfiles(missingProfiles)
+                for (chunk in missingProfiles.chunked(METADATA_CHUNK_SIZE)) {
+                    nostrService.fetchMissingProfiles(chunk)
+                    delay(METADATA_CHUNK_DELAY_MS)
+                }
                 delay(PROFILE_FETCH_WAIT_MS)
             }
 

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NostrMentions.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NostrMentions.kt
@@ -53,6 +53,19 @@ object NostrMentions {
         }
     }
 
+    /**
+     * Every pubkey [content] mentions, hex, in appearance order.
+     *
+     * Lets a caller resolve exactly the profiles one note can display instead
+     * of reading the whole profile map, which is what makes a feed row's
+     * profile lookups narrowable to that row.
+     */
+    fun mentionedPubkeys(content: String): List<String> =
+        MENTION_REGEX.findAll(content)
+            .mapNotNull { resolvePubkey(it.groupValues[1]) }
+            .distinct()
+            .toList()
+
     /** Display label for a mention: the profile's best name, else a short pubkey. */
     private fun displayName(pubkey: String, profiles: Map<String, FeedProfile>): String =
         profiles[pubkey]?.bestName ?: "${pubkey.take(8)}…"

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
@@ -63,6 +63,7 @@ import com.nostrvault.ui.components.CompactNoteCard
 import com.nostrvault.ui.components.GlassPill
 import com.nostrvault.ui.components.GlassScaffold
 import com.nostrvault.ui.components.NoteCard
+import com.nostrvault.ui.components.NostrMentions
 import com.nostrvault.ui.components.ScrollCondenseEffect
 import com.nostrvault.ui.components.SkeletonFeed
 import com.nostrvault.service.ScrollPosition
@@ -99,7 +100,10 @@ fun FeedScreen(
     val isLoadingMore by viewModel.isLoadingMore.collectAsState()
     val connectionStatus by viewModel.connectionStatus.collectAsState()
     val connectionColor by viewModel.connectionColor.collectAsState()
-    val allProfiles by viewModel.profiles.collectAsState()
+    // Read straight off the ViewModel's snapshot map. Collecting it here would
+    // subscribe the whole screen to every metadata batch; each feed row narrows
+    // its own read below instead.
+    val allProfiles = viewModel.profileState
     val isCompact by viewModel.compactModeEnabled.collectAsState()
     val autoLoad by viewModel.autoLoadEnabled.collectAsState()
     val showReposts by viewModel.showReposts.collectAsState()
@@ -423,21 +427,32 @@ fun FeedScreen(
                         val isExpanded = isCompact && expandedNoteId == note.id
                         val showCompact = isCompact && !isExpanded
 
-                        // Cache profile lookups to avoid redundant map reads during recomposition
-                        val noteProfile = remember(note.id, note.pubkey) {
-                            viewModel.profileFor(note.pubkey)
-                        }
-                        val repostedByProfile = remember(note.id, note.repostedBy) {
-                            note.repostedBy?.let { viewModel.profileFor(it) }
+                        // Exactly the pubkeys this card can render: its author, the
+                        // reposter, the reply target, and anyone the text mentions.
+                        // Quoted notes and the parent are added below where they resolve.
+                        val headPubkeys = remember(note.id) {
+                            buildList {
+                                add(note.pubkey)
+                                note.repostedBy?.let(::add)
+                                note.replyToPubkey?.let(::add)
+                                addAll(NostrMentions.mentionedPubkeys(note.content))
+                            }.distinct()
                         }
 
                         // Remove expensive Crossfade animation for better scroll performance
                         if (showCompact) {
+                            // derivedStateOf, not a plain read: the computation re-runs on
+                            // every metadata batch, but this row only recomposes when one of
+                            // *its* profiles actually changed. Reading allProfiles directly
+                            // here would rebuild every visible card per batch instead.
+                            val cardProfiles by remember(headPubkeys) {
+                                derivedStateOf { headPubkeys.resolveAgainst(allProfiles) }
+                            }
                             CompactNoteCard(
                                 note = note,
-                                profile = noteProfile,
-                                profiles = allProfiles,
-                                repostedByProfile = repostedByProfile,
+                                profile = cardProfiles[note.pubkey],
+                                profiles = cardProfiles,
+                                repostedByProfile = note.repostedBy?.let { cardProfiles[it] },
                                 onNoteClick = { id ->
                                     // Expand inline first instead of navigating
                                     expandedNoteId = id
@@ -446,10 +461,6 @@ fun FeedScreen(
                                 modifier = Modifier.padding(horizontal = 10.dp, vertical = 2.dp),
                             )
                         } else {
-                            val replyToProfile = remember(note.id, note.replyToPubkey) {
-                                note.replyToPubkey?.let { viewModel.profileFor(it) }
-                            }
-
                             val parentEventId = note.parentEventId
                             val parentNote = parentEventId?.let { viewModel.parentNoteFor(it) }
                             val isParentNext = parentEventId?.let { viewModel.isParentNext(note.id) } ?: false
@@ -467,17 +478,29 @@ fun FeedScreen(
                                 }
                             }
 
+                            // See the compact branch: derivedStateOf keeps a metadata
+                            // batch from recomposing cards it did not touch. The parent and
+                            // quoted authors join the set once those notes resolve.
+                            val cardPubkeys = remember(headPubkeys, parentNote?.pubkey, quotedNotesMap) {
+                                (headPubkeys +
+                                    listOfNotNull(parentNote?.pubkey) +
+                                    quotedNotesMap.values.map { it.pubkey }).distinct()
+                            }
+                            val cardProfiles by remember(cardPubkeys) {
+                                derivedStateOf { cardPubkeys.resolveAgainst(allProfiles) }
+                            }
+
                             NoteCard(
                                 note = note,
-                                profile = noteProfile,
+                                profile = cardProfiles[note.pubkey],
                                 stats = viewModel.statsFor(note.id),
-                                profiles = allProfiles,
+                                profiles = cardProfiles,
                                 quotedNotes = quotedNotesMap,
                                 isLiked = viewModel.isLiked(note.id),
                                 isZapped = viewModel.isZapped(note.id),
                                 isReposted = note.effectiveEventId in repostedIds,
-                                repostedByProfile = repostedByProfile,
-                                replyToProfile = replyToProfile,
+                                repostedByProfile = note.repostedBy?.let { cardProfiles[it] },
+                                replyToProfile = note.replyToPubkey?.let { cardProfiles[it] },
                                 parentNote = parentNote,
                                 parentIsNext = isParentNext,
                                 showReplyContext = true,
@@ -1313,4 +1336,19 @@ private fun NewPostsPill(count: Int, onClick: () -> Unit, modifier: Modifier = M
             color = PrimaryText,
         )
     }
+}
+
+/**
+ * The subset of [profiles] this list of pubkeys names, dropping the ones the
+ * relay has not answered yet. Small by construction — a handful of entries per
+ * feed row — so a card is handed only what it can draw rather than the whole
+ * profile cache.
+ */
+private fun List<String>.resolveAgainst(
+    profiles: Map<String, FeedProfile>,
+): Map<String, FeedProfile> {
+    if (isEmpty()) return emptyMap()
+    val resolved = HashMap<String, FeedProfile>(size)
+    for (pubkey in this) profiles[pubkey]?.let { resolved[pubkey] = it }
+    return resolved
 }

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedViewModel.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedViewModel.kt
@@ -1,5 +1,7 @@
 package com.nostrvault.ui.screens.feed
 
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nostrvault.data.local.ConfigStore
@@ -16,17 +18,20 @@ import com.nostrvault.service.ScrollPosition
 import com.nostrvault.service.ZapSendService
 import com.nostrvault.ui.notification.NotificationManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
  * ViewModel for the main feed screen.
  * Bridges FeedService + NostrService state into composable-friendly flows.
  */
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class FeedViewModel @Inject constructor(
     private val feedService: FeedService,
@@ -36,6 +41,11 @@ class FeedViewModel @Inject constructor(
     private val zapSendService: ZapSendService,
     private val liveFeedService: LiveFeedService,
 ) : ViewModel() {
+
+    private companion object {
+        /** Relays answer metadata in bursts; three UI passes a second is plenty. */
+        const val PROFILE_SAMPLE_MS = 300L
+    }
 
     /**
      * Live streams come from their own service rather than the note list: a
@@ -57,14 +67,23 @@ class FeedViewModel @Inject constructor(
     // ── Feed state ───────────────────────────────────────────────
 
     val notes: StateFlow<List<FeedNote>> = feedService.notes
-    // Profiles stream in continuously as notes are fetched. Emitting on every
-    // single insertion recomposed the whole visible feed per-profile while
-    // scrolling. Sample so bursts coalesce to ~3/sec; mentions/avatars still
-    // resolve within a frame or two. profileFor() below still reads the live map.
-    @OptIn(FlowPreview::class)
-    val profiles: StateFlow<Map<String, FeedProfile>> = nostrService.profiles
-        .sample(300L) // coalesce profile bursts to ~3/sec while scrolling
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), nostrService.profiles.value)
+
+    /**
+     * Profiles as Compose state rather than a `StateFlow` the screen collects.
+     *
+     * This alone is not the win — `SnapshotStateMap` has one state record, so
+     * any write invalidates every scope that read the map, exactly like a new
+     * `Map` instance would. What it buys is *where* the read happens: the
+     * screen no longer holds a `collectAsState` at the top of the composition,
+     * so each feed row can wrap its own lookups in `derivedStateOf` and be
+     * invalidated only when the profiles that row actually shows change. See
+     * `FeedScreen`'s per-row `cardProfiles`.
+     *
+     * Still sampled, because the relay answers a metadata batch in bursts and
+     * three UI passes a second is plenty for a name appearing.
+     */
+    val profileState: SnapshotStateMap<String, FeedProfile> =
+        mutableStateMapOf<String, FeedProfile>().apply { putAll(nostrService.profiles.value) }
     val noteStats: StateFlow<Map<String, NoteStats>> = feedService.noteStats
     val likedEventIds: StateFlow<Set<String>> = feedService.likedEventIds
     val zappedEventIds: StateFlow<Map<String, Int>> = feedService.zappedEventIds
@@ -87,6 +106,29 @@ class FeedViewModel @Inject constructor(
     }
 
     init {
+        // Diff the profile map off the main thread and write only what changed:
+        // the cache holds up to 5,000 entries, and scanning that on the main
+        // thread three times a second would cost more than the recompositions
+        // this is here to avoid.
+        viewModelScope.launch(Dispatchers.Default) {
+            nostrService.profiles.sample(PROFILE_SAMPLE_MS).collect { snapshot ->
+                val changed = snapshot.filterTo(HashMap()) { (pubkey, profile) ->
+                    profileState[pubkey] != profile
+                }
+                // Entries only disappear when the service trims its cache.
+                val dropped = if (snapshot.size < profileState.size) {
+                    profileState.keys.filterTo(ArrayList()) { it !in snapshot }
+                } else {
+                    emptyList()
+                }
+                if (changed.isEmpty() && dropped.isEmpty()) return@collect
+                withContext(Dispatchers.Main) {
+                    profileState.putAll(changed)
+                    dropped.forEach { profileState.remove(it) }
+                }
+            }
+        }
+
         // Staggered startup: wait for relay to be ready before loading feed
         // to avoid OOM from relay + feed + media all starting simultaneously.
         viewModelScope.launch {


### PR DESCRIPTION
Triage and implementation of the Android feed-performance work Sentry reviewed. Foundry made no commit and its `.scratch/foundry-android-feed-performance` does not exist on this machine, so this is a re-implementation against Sentry's review rather than a merge of that diff.

## What is here

**1. A fresh clone could not build the app.** (`6f06fcc`)

Two configuration-time defects, both invisible once a machine has built successfully:

- `.gitignore` had a blanket `*.txt` that swallowed `NostrVault/app/src/main/CMakeLists.txt`, the file `app/build.gradle.kts` requires. This is what Foundry reported as a "declared but missing" file — it is not missing, it was ignored. `git status --ignored` confirms the pattern was hiding exactly that one file, so narrowing it to `/*.txt` costs nothing.
- The release `signingConfig` cast four `local.properties` values with unconditional `as String`. `local.properties` is untracked, so on a checkout without one the cast threw during configuration and failed *every* task, `compileDebugKotlin` and the unit tests included. Now created only when all four values are present.

Proven by deleting `local.properties` from the worktree entirely: `compileDebugKotlin` succeeds, and `assembleDebug` packages `app-debug.apk` (50 MB). One gap is left deliberately — `jniLibs/arm64-v8a/libhaven.so` is a Go build product, stays untracked, rebuilt with `just android-build`.

**2. Names and avatars stayed as fallbacks forever.** (`08ad6c2`) — Sentry's blocker

`FeedScreen` cached each row's profile with `remember(note.id, note.pubkey)`. The key is the note, and the note never changes, so a row composed before its author's kind-0 arrived kept that `null` for the row's whole life. The metadata pipeline was fine; the row never asked again.

Reading the live map on every recomposition would have traded that for the jank Sentry raised next (one batch rebuilding every visible card). Both go away together:

- `FeedViewModel` exposes profiles as a `SnapshotStateMap`, updated by a diff computed on `Dispatchers.Default`. The map is *not* key-granular on its own — it has one state record — what it buys is that the screen no longer holds a `collectAsState`.
- Each row resolves only the profiles it can draw (author, reposter, reply target, parent, quoted authors, mentions) inside `derivedStateOf`. The computation re-runs per batch — a handful of lookups per visible row — but `derivedStateOf` compares the result, so a row recomposes only when a profile it actually shows changed. Cards get that small map, so nothing downstream re-subscribes to the full cache.

**3. The avatar prefetch asked for every follow at once.** (`431ac91`) — Sentry's third finding

Ten seconds after launch, `ProfilePicturePrefetcher` handed the whole follow list to `fetchMissingProfiles`, which coalesces it into one metadata REQ. On a few-thousand-follow account, the kind-0 flood lands on the feed exactly while it is being scrolled. Chunked to 100 per REQ, 750 ms apart.

## Evidence

- `compileDebugKotlin` — success, with `local.properties` absent
- `testDebugUnitTest --rerun-tasks` — **38 tests, 0 failures, 0 errors**
- `lintDebug` — success
- `assembleDebug` — `app-debug.apk` produced

## Not verified

Device behaviour. Nobody has watched a fallback name resolve under real delayed metadata, or measured scroll frame times before/after. The recomposition argument above is a reading of the Compose semantics, not a trace. Worth a run on the moto g play before this is treated as a measured win.

## Dropped from Foundry's report

- The `NoteDetailScreen` reply-tree index — that file is untouched here. It is a real improvement and should be its own PR against the current master; folding it in unreviewed alongside the feed change would make both harder to judge.
- Removing the 100 ms media crossfades — a visual change with no measurement attached to it. Not included.