### PR TITLE
Notes tab: stop embedding the Relay dashboard

### DIFF
--- a/HavenApp/HavenApp/Views/Vault/VaultView.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultView.swift
@@ -429,49 +429,32 @@ struct VaultView: View {
                 Color.platformWindowBackground.ignoresSafeArea()
 
                 if geometry.size.width > 680 {
-                    let availableDashboardHeight = max(420, geometry.size.height - 300)
-                    let preferredDashboardHeight = max(620, geometry.size.height * 0.56)
-                    let dashboardHeight = min(preferredDashboardHeight, availableDashboardHeight)
-
                     VStack(spacing: 0) {
-                        DashboardView(isSidebar: false)
-                            .frame(height: dashboardHeight)
-                            .clipped()
-                            .environmentObject(relayManager)
-                            .environmentObject(configService)
-                            .environmentObject(nostrService)
-                            .environmentObject(StatsService.shared)
+                        desktopHeaderView
 
                         Divider()
-                            .background(Color.platformSeparator)
 
-                        VStack(spacing: 0) {
-                            desktopHeaderView
+                        ScrollView {
+                            listContent
 
-                            Divider()
-
-                            ScrollView {
-                                listContent
-
-                                if !displayNotes.isEmpty || !displayLikedNotes.isEmpty {
-                                    Color.clear
-                                        .frame(height: 1)
-                                        .padding(.bottom, 20)
-                                        .onAppear {
-                                            if !nostrService.isFetching && !displayNotes.isEmpty {
-                                                loadMore()
-                                            }
+                            if !displayNotes.isEmpty || !displayLikedNotes.isEmpty {
+                                Color.clear
+                                    .frame(height: 1)
+                                    .padding(.bottom, 20)
+                                    .onAppear {
+                                        if !nostrService.isFetching && !displayNotes.isEmpty {
+                                            loadMore()
                                         }
-                                        .id(nostrService.events.count)
-                                }
+                                    }
+                                    .id(nostrService.events.count)
                             }
-                            .refreshable {
-                                refreshAll(.incremental)
-                            }
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                         }
-                        .clipped()
+                        .refreshable {
+                            refreshAll(.incremental)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
+                    .clipped()
                 } else {
                     if showingRelayDashboard {
                         VStack(spacing: 0) {


### PR DESCRIPTION
## Summary
- Wide macOS windows pinned a full `DashboardView` above the note list in `VaultView.swift`, making the Notes tab look identical to the dedicated Relay sidebar tab.
- Removes the embedded dashboard from the wide-window Notes layout so Notes only shows the note list; the Relay tab and the narrow-window "Relay" sheet still carry the dashboard.

## Test plan
- [x] `xcodebuild -project HavenApp.xcodeproj -scheme HavenApp -destination 'platform=macOS' build` — BUILD SUCCEEDED
- [ ] Logen to eyeball the wide-window Notes tab on device (this shell has no screen-recording permission)