### PR TITLE
ui(macos): relay tab — show the relay's address, fix the dead pulse, silent exports, and missing Stop

### DIFF
--- a/HavenApp/HavenApp/Services/RelayProcessManager.swift
+++ b/HavenApp/HavenApp/Services/RelayProcessManager.swift
@@ -486,6 +486,9 @@ class RelayProcessManager: ObservableObject {
         state = .idle
         isRunning = false
         isWotSyncing = false
+        // Cleared so the dashboard's uptime readout does not keep counting
+        // against a run that has already ended.
+        startDate = nil
         isShuttingDown = false
         #if os(macOS)
         NetworkSyncService.shared.stop()

--- a/HavenApp/HavenApp/Views/Components/ActionButton.swift
+++ b/HavenApp/HavenApp/Views/Components/ActionButton.swift
@@ -1,13 +1,30 @@
 import SwiftUI
 
 struct ActionButton: View {
+    /// How loudly a button asks to be pressed. The relay dashboard offers five
+    /// actions at once; rendering them all as filled accent tiles meant nothing
+    /// signalled which one you came here for.
+    enum Emphasis {
+        /// Filled accent. The action this group exists for.
+        case primary
+        /// Tinted outline. Supporting actions that sit beside the primary one.
+        case secondary
+    }
+
     let icon: String
     let title: String
     var isLoading: Bool = false
+    var emphasis: Emphasis = .primary
     let action: () -> Void
 
-    @Environment(\.controlSize) private var controlSize
+    @Environment(\.isEnabled) private var isEnabled
     @State private var isHovered = false
+
+    private var foreground: Color {
+        emphasis == .primary ? .white : Color.havenPurpleLight
+    }
+
+    private var isHighlighted: Bool { isHovered && isEnabled }
 
     var body: some View {
         Button(action: action) {
@@ -19,34 +36,58 @@ struct ActionButton: View {
                 } else {
                     Image(systemName: icon)
                         .font(.appSystem(size: 20, weight: .medium))
-                        .foregroundColor(.white)
+                        .foregroundColor(foreground)
                 }
                 Text(title)
                     .font(.appSystem(size: 13, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(foreground)
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .background(
-                LinearGradient(
-                    gradient: Gradient(colors: [Color.havenPurple, Color.havenPurpleDark]),
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
+            .background(background)
             .cornerRadius(12)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.white.opacity(0.12), lineWidth: 0.5)
+                    .stroke(borderColor, lineWidth: emphasis == .primary ? 0.5 : 1)
             )
-            .scaleEffect(isHovered ? 1.03 : 1.0)
-            .shadow(color: Color.havenPurple.opacity(isHovered ? 0.35 : 0.0), radius: 8, x: 0, y: 4)
+            // Disabled controls have to *look* disabled: SwiftUI dims a plain
+            // button style so little that the grid read as fully live while the
+            // relay was stopped.
+            .opacity(isEnabled ? 1.0 : 0.4)
+            .scaleEffect(isHighlighted ? 1.03 : 1.0)
+            .shadow(color: Color.havenPurple.opacity(isHighlighted && emphasis == .primary ? 0.35 : 0.0), radius: 8, x: 0, y: 4)
             .animation(Motion.control, value: isHovered)
+            .animation(Motion.control, value: isEnabled)
         }
         .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
+        }
+        .accessibilityLabel(Text(title))
+        .accessibilityHint(isLoading ? Text("In progress") : Text("Runs the \(title) task"))
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        switch emphasis {
+        case .primary:
+            LinearGradient(
+                gradient: Gradient(colors: [Color.havenPurple, Color.havenPurpleDark]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        case .secondary:
+            Color.havenPurple.opacity(isHighlighted ? 0.20 : 0.12)
+        }
+    }
+
+    private var borderColor: Color {
+        switch emphasis {
+        case .primary:
+            return Color.white.opacity(0.12)
+        case .secondary:
+            return Color.havenPurple.opacity(isHighlighted ? 0.65 : 0.4)
         }
     }
 }

--- a/HavenApp/HavenApp/Views/Components/StatsCard.swift
+++ b/HavenApp/HavenApp/Views/Components/StatsCard.swift
@@ -65,5 +65,12 @@ struct StatsCard: View {
         .onHover { hovering in
             withAnimation(Motion.control) { isHovered = hovering && action != nil }
         }
+        // The card reads as icon + big number + caption, which VoiceOver would
+        // otherwise announce as three unrelated fragments in the wrong order.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(title))
+        .accessibilityValue(isLoading ? Text("Loading") : Text(value))
+        .accessibilityAddTraits(action != nil ? .isButton : [])
+        .accessibilityHint(action != nil ? Text("Shows a detailed breakdown") : Text(""))
     }
 }

--- a/HavenApp/HavenApp/Views/Dashboard/DashboardBreakdowns.swift
+++ b/HavenApp/HavenApp/Views/Dashboard/DashboardBreakdowns.swift
@@ -489,7 +489,19 @@ struct MediaCacheBreakdownView: View {
 
 struct StorageBreakdownView: View {
     @EnvironmentObject var statsService: StatsService
+    @EnvironmentObject var configService: ConfigService
     @Environment(\.dismiss) private var dismiss
+
+    @State private var showingBlossomBreakdown = false
+    @State private var showingCacheBreakdown = false
+
+    /// Which detail view a bucket opens, if any. The dashboard used to give
+    /// Blossom and the media cache their own stat cards; they are reachable
+    /// from here now, one level down from the total they are part of.
+    private enum StorageDetail {
+        case blossom
+        case cache
+    }
 
     private struct StorageBucket: Identifiable {
         let id = UUID()
@@ -497,14 +509,15 @@ struct StorageBreakdownView: View {
         let icon: String
         let color: Color
         let size: Int64
+        var detail: StorageDetail? = nil
     }
 
     private var buckets: [StorageBucket] {
         let dbSize = max(0, statsService.storageSize - statsService.blossomSize - statsService.cacheSize - statsService.thumbnailSize)
         return [
             StorageBucket(label: "Database", icon: "cylinder.fill", color: .blue, size: dbSize),
-            StorageBucket(label: "Blossom Media", icon: "camera.macro", color: .green, size: statsService.blossomSize),
-            StorageBucket(label: "Media Cache", icon: "photo.stack.fill", color: .orange, size: statsService.cacheSize + statsService.thumbnailSize),
+            StorageBucket(label: "Blossom Media", icon: "camera.macro", color: .green, size: statsService.blossomSize, detail: .blossom),
+            StorageBucket(label: "Media Cache", icon: "photo.stack.fill", color: .orange, size: statsService.cacheSize + statsService.thumbnailSize, detail: .cache),
         ].filter { $0.size > 0 }
     }
 
@@ -539,7 +552,15 @@ struct StorageBreakdownView: View {
                                     icon: bucket.icon,
                                     color: bucket.color,
                                     size: bucket.size,
-                                    total: statsService.storageSize
+                                    total: statsService.storageSize,
+                                    action: bucket.detail.map { detail in
+                                        {
+                                            switch detail {
+                                            case .blossom: showingBlossomBreakdown = true
+                                            case .cache: showingCacheBreakdown = true
+                                            }
+                                        }
+                                    }
                                 )
                             }
                         }
@@ -566,6 +587,15 @@ struct StorageBreakdownView: View {
         #if os(macOS)
         .frame(minWidth: 520, idealWidth: 560, minHeight: 560, idealHeight: 640)
         #endif
+        .sheet(isPresented: $showingBlossomBreakdown) {
+            BlossomBreakdownView()
+                .environmentObject(statsService)
+                .environmentObject(configService)
+        }
+        .sheet(isPresented: $showingCacheBreakdown) {
+            MediaCacheBreakdownView()
+                .environmentObject(statsService)
+        }
     }
 }
 

--- a/HavenApp/HavenApp/Views/Dashboard/DashboardHelpers.swift
+++ b/HavenApp/HavenApp/Views/Dashboard/DashboardHelpers.swift
@@ -61,13 +61,26 @@ struct StorageRow: View {
     let color: Color
     let size: Int64
     let total: Int64
+    /// Buckets that have a detail view of their own become tappable rows.
+    var action: (() -> Void)? = nil
 
     private var sizePercent: Double {
         guard total > 0 else { return 0 }
         return Double(size) / Double(total)
     }
 
+    @ViewBuilder
     var body: some View {
+        if let action {
+            Button(action: action) { content }
+                .buttonStyle(.plain)
+                .accessibilityHint(Text("Shows what is stored here"))
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.appSystem(size: 16, weight: .semibold))
@@ -87,6 +100,12 @@ struct StorageRow: View {
                 Text(String(format: "%.1f%%", sizePercent * 100))
                     .font(.appSystem(size: 10, design: .monospaced))
                     .foregroundColor(.secondary)
+            }
+
+            if action != nil {
+                Image(systemName: "chevron.right")
+                    .font(.appSystem(size: 10, weight: .semibold))
+                    .foregroundColor(.secondary.opacity(0.6))
             }
         }
         .padding(.horizontal, 12)

--- a/HavenApp/HavenApp/Views/Dashboard/DashboardView.swift
+++ b/HavenApp/HavenApp/Views/Dashboard/DashboardView.swift
@@ -12,10 +12,10 @@ struct DashboardView: View {
     @State private var isBackingUpBlossom = false
     @State private var isPreparingImport = false
     @State private var exportStatusMessage = ""
+    @State private var exportStatusIsError = false
     @State private var statusAnimate = false
+    @State private var didCopyAddress = false
     @State private var showingKindBreakdown = false
-    @State private var showingBlossomBreakdown = false
-    @State private var showingCacheBreakdown = false
     @State private var showingStorageBreakdown = false
     @State private var showingFullLogs = false
     @State private var shareSheetURL: URL?
@@ -64,18 +64,12 @@ struct DashboardView: View {
             EventKindBreakdownView()
                 .environmentObject(statsService)
         }
-        .sheet(isPresented: $showingBlossomBreakdown) {
-            BlossomBreakdownView()
-                .environmentObject(statsService)
-                .environmentObject(configService)
-        }
-        .sheet(isPresented: $showingCacheBreakdown) {
-            MediaCacheBreakdownView()
-                .environmentObject(statsService)
-        }
         .sheet(isPresented: $showingStorageBreakdown) {
+            // Blossom and media-cache detail now hang off the storage breakdown
+            // rather than competing with it for a slot in the stat grid.
             StorageBreakdownView()
                 .environmentObject(statsService)
+                .environmentObject(configService)
         }
         .sheet(isPresented: $showingFullLogs) {
             NavigationStack {
@@ -96,58 +90,17 @@ struct DashboardView: View {
     #if os(macOS)
     private func macOSConsoleLayout(geometry: GeometryProxy) -> some View {
         VStack(spacing: 12) {
-            relayStatusHeader
+            relayStatusHeader(isCompact: false)
                 .padding(.top, 8)
                 .background(Color.platformWindowBackground)
-            
-            // Statistics Grid (Full Width 4 Columns)
-            let statsColumns = [
-                GridItem(.flexible()),
-                GridItem(.flexible()),
-                GridItem(.flexible()),
-                GridItem(.flexible())
-            ]
-            
-            LazyVGrid(columns: statsColumns, spacing: 12) {
-                StatsCard(
-                    title: "Total Relay Events",
-                    value: "\(statsService.loadedEventsCount)",
-                    icon: "doc.text.fill",
-                    color: Color.havenPurple,
-                    isLoading: statsService.isUpdatingCount && statsService.loadedEventsCount == 0,
-                    action: { showingKindBreakdown = true }
-                )
 
-                StatsCard(
-                    title: "Storage Used",
-                    value: statsService.formattedStorageSize,
-                    icon: "internaldrive.fill",
-                    color: .blue,
-                    action: { showingStorageBreakdown = true }
-                )
-
-                StatsCard(
-                    title: "Blossom Storage",
-                    value: statsService.formattedBlossomSize,
-                    icon: "camera.macro",
-                    color: .green,
-                    action: { showingBlossomBreakdown = true }
-                )
-
-                StatsCard(
-                    title: "Media Cache",
-                    value: statsService.formattedCacheSize,
-                    icon: "photo.stack.fill",
-                    color: .orange,
-                    action: { showingCacheBreakdown = true }
-                )
-            }
-            .padding(.horizontal)
-            
-            // Side-by-Side Console & Controls
+            // Left rail carries status detail and controls; the console — the
+            // thing you actually watch — gets the full remaining height instead
+            // of a stats band pushing it down.
             HStack(alignment: .top, spacing: 16) {
-                // Left Column: Actions
                 VStack(alignment: .leading, spacing: 12) {
+                    statsGrid
+
                     if relayManager.isImporting {
                         importProgressSection
                     }
@@ -157,79 +110,16 @@ struct DashboardView: View {
                     }
 
                     if !relayManager.isImporting {
-                        let actionColumns = [
-                            GridItem(.flexible()),
-                            GridItem(.flexible())
-                        ]
-
-                        LazyVGrid(columns: actionColumns, spacing: 8) {
-                            ActionButton(icon: "safari", title: "Browser") {
-                                if let url = URL(string: configService.config.webURL) {
-                                    NSWorkspace.shared.open(url)
-                                }
-                            }
-
-                            ActionButton(icon: "arrow.down.circle", title: "Import", isLoading: isPreparingImport || relayManager.isImporting) {
-                                isPreparingImport = true
-                                relayManager.importNotes(config: configService.config)
-                            }
-                            .disabled(isPreparingImport || relayManager.isImporting)
-
-                            ActionButton(icon: "photo.on.rectangle.angled", title: "Import Blossom", isLoading: mirrorService.state == .mirroring) {
-                                mirrorService.runMirror(configService: configService, nostrService: nostrService)
-                            }
-                            .disabled(mirrorService.state == .mirroring)
-
-                            ActionButton(icon: "arrow.up.doc.fill", title: "Export JSONL", isLoading: isExporting) {
-                                exportBackup()
-                            }
-                            .disabled(isExporting || isBackingUpBlossom)
-
-                            ActionButton(icon: "photo.stack", title: "Export Media", isLoading: isBackingUpBlossom) {
-                                exportBlossom()
-                            }
-                            .disabled(isExporting || isBackingUpBlossom)
-                        }
+                        actionGrid
                     }
+
+                    exportStatusView
+
+                    Spacer(minLength: 0)
                 }
                 .frame(width: 380)
-                
-                // Right Column: System Terminal Logs
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Image(systemName: "terminal.fill")
-                            .font(.appSystem(size: 10, weight: .bold))
-                            .foregroundColor(.green)
-                        
-                        Text("LOCAL RELAY SERVER CONSOLE")
-                            .font(.appSystem(size: 10, weight: .bold, design: .monospaced))
-                            .foregroundColor(.secondary)
-                        
-                        Spacer()
-                        
-                        HStack(spacing: 5) {
-                            Circle().fill(Color.red.opacity(0.7)).frame(width: 7, height: 7)
-                            Circle().fill(Color.yellow.opacity(0.7)).frame(width: 7, height: 7)
-                            Circle().fill(Color.green.opacity(0.7)).frame(width: 7, height: 7)
-                        }
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(Color.platformConsoleHeaderBackground)
-                    
-                    Divider()
-                        .background(Color.platformCardBorder)
-                    
-                    LogsView(logStore: relayManager.logStore, hideHeader: true)
-                        .frame(maxHeight: .infinity)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.platformTertiaryGroupedBackground)
-                .cornerRadius(8)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color.green.opacity(0.12), lineWidth: 1)
-                )
+
+                relayConsole
             }
             .padding(.horizontal)
             .padding(.bottom, 12)
@@ -237,7 +127,57 @@ struct DashboardView: View {
         .frame(maxHeight: .infinity, alignment: .top)
         .background(Color.platformWindowBackground.ignoresSafeArea())
     }
+
+    /// The full-height console used by the wide layout.
+    private var relayConsole: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            consoleHeader(title: "LOCAL RELAY SERVER CONSOLE")
+
+            Divider()
+                .background(Color.platformCardBorder)
+
+            LogsView(logStore: relayManager.logStore, hideHeader: true)
+                .frame(maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.platformTertiaryGroupedBackground)
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.green.opacity(0.12), lineWidth: 1)
+        )
+    }
+
     #endif
+
+    /// `trailing` is the compact console's "View All" affordance. The wide
+    /// console has no trailing control — it used to carry three fake macOS
+    /// window buttons, which look clickable on macOS and do nothing.
+    ///
+    /// Deliberately shows no live log count: `LogStore` is a separate
+    /// observable so log traffic only redraws `LogsView`, and reading its
+    /// count here would either go stale or undo that.
+    private func consoleHeader<Trailing: View>(
+        title: String,
+        @ViewBuilder trailing: () -> Trailing = { EmptyView() }
+    ) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "terminal.fill")
+                .font(.appSystem(size: 10, weight: .bold))
+                .foregroundColor(.green)
+
+            Text(title)
+                .font(.appSystem(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            trailing()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.platformConsoleHeaderBackground)
+    }
 
     private func iOSConsoleLayout(geometry: GeometryProxy) -> some View {
         VStack(spacing: 0) {
@@ -259,7 +199,7 @@ struct DashboardView: View {
                 #endif
             }
             
-            relayStatusHeader
+            relayStatusHeader(isCompact: geometry.size.width < 480)
                 .padding(.top, isSidebar ? 4 : 8)
                 .background(Color.platformWindowBackground)
             
@@ -288,52 +228,12 @@ struct DashboardView: View {
                             blossomImportSection
                         }
 
-                        let actionColumns = [GridItem(.flexible()), GridItem(.flexible())]
+                        actionGrid
+                            .padding(.horizontal)
 
-                        LazyVGrid(columns: actionColumns, spacing: 10) {
-                            #if os(macOS)
-                            ActionButton(icon: "safari", title: "Open Browser") {
-                                if let url = URL(string: configService.config.webURL) {
-                                    #if os(macOS)
-                                    NSWorkspace.shared.open(url)
-                                    #else
-                                    UIApplication.shared.open(url)
-                                    #endif
-                                }
-                            }
-                            #endif
-
-                            ActionButton(icon: "arrow.down.circle", title: "Import Notes", isLoading: isPreparingImport || relayManager.isImporting) {
-                                isPreparingImport = true
-                                relayManager.importNotes(config: configService.config)
-                            }
-                            .disabled(isPreparingImport || relayManager.isImporting)
-
-                            ActionButton(icon: "photo.on.rectangle.angled", title: "Import Blossom", isLoading: mirrorService.state == .mirroring) {
-                                mirrorService.runMirror(configService: configService, nostrService: nostrService)
-                            }
-                            .disabled(mirrorService.state == .mirroring)
-
-                            ActionButton(icon: "arrow.up.doc.fill", title: "Export JSONL", isLoading: isExporting) {
-                                exportBackup()
-                            }
-                            .disabled(isExporting || isBackingUpBlossom)
-
-                            ActionButton(icon: "photo.stack", title: "Export Blossom", isLoading: isBackingUpBlossom) {
-                                exportBlossom()
-                            }
-                            .disabled(isExporting || isBackingUpBlossom)
-                        }
-                        .padding(.horizontal)
-
-                        if !exportStatusMessage.isEmpty {
-                            Text(exportStatusMessage)
-                                .font(.appCaption)
-                                .foregroundColor(.secondary)
-                                .padding(.horizontal)
-                        }
+                        exportStatusView
+                            .padding(.horizontal)
                     }
-                    .disabled(!relayManager.isRunning && !relayManager.isImporting)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
@@ -365,31 +265,111 @@ struct DashboardView: View {
                 .foregroundColor(.secondary)
                 .padding(.horizontal)
 
-            let columns = [GridItem(.flexible()), GridItem(.flexible())]
+            statsGrid
+                .padding(.horizontal)
+        }
+    }
 
-            LazyVGrid(columns: columns, spacing: 8) {
-                StatsCard(title: "Total Relay Events", value: "\(statsService.loadedEventsCount)", icon: "doc.text.fill", color: Color.havenPurple, isLoading: statsService.isUpdatingCount && statsService.loadedEventsCount == 0, action: { showingKindBreakdown = true })
-                StatsCard(title: "Storage Used", value: statsService.formattedStorageSize, icon: "internaldrive.fill", color: .blue, action: { showingStorageBreakdown = true })
-                StatsCard(title: "Blossom Storage", value: statsService.formattedBlossomSize, icon: "camera.macro", color: .green, action: { showingBlossomBreakdown = true })
-                StatsCard(title: "Media Cache", value: statsService.formattedCacheSize, icon: "photo.stack.fill", color: .orange, action: { showingCacheBreakdown = true })
+    /// Two cards, not four. "Storage Used", "Blossom Storage" and "Media Cache"
+    /// were three views of the same number with no hint which one mattered;
+    /// the storage breakdown already splits the total three ways and now drills
+    /// into the Blossom and cache detail from there.
+    private var statsGrid: some View {
+        let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+        return LazyVGrid(columns: columns, spacing: 8) {
+            StatsCard(
+                title: "Total Relay Events",
+                value: "\(statsService.loadedEventsCount)",
+                icon: "doc.text.fill",
+                color: Color.havenPurple,
+                isLoading: statsService.isUpdatingCount && statsService.loadedEventsCount == 0,
+                action: { showingKindBreakdown = true }
+            )
+            StatsCard(
+                title: "Storage Used",
+                value: statsService.formattedStorageSize,
+                icon: "internaldrive.fill",
+                color: .blue,
+                action: { showingStorageBreakdown = true }
+            )
+        }
+    }
+
+    /// Import and export are not peers: one pulls data in over the network for
+    /// minutes, the others write a file. Exports read as tinted, not filled.
+    private var actionGrid: some View {
+        let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+        return VStack(alignment: .leading, spacing: 8) {
+            LazyVGrid(columns: columns, spacing: 10) {
+                ActionButton(icon: "arrow.down.circle", title: "Import Notes", isLoading: isPreparingImport || relayManager.isImporting) {
+                    isPreparingImport = true
+                    relayManager.importNotes(config: configService.config)
+                }
+                .disabled(isPreparingImport || relayManager.isImporting)
+
+                ActionButton(icon: "photo.on.rectangle.angled", title: "Import Blossom", isLoading: mirrorService.state == .mirroring) {
+                    mirrorService.runMirror(configService: configService, nostrService: nostrService)
+                }
+                .disabled(mirrorService.state == .mirroring)
+
+                ActionButton(icon: "arrow.up.doc.fill", title: "Export JSONL", isLoading: isExporting, emphasis: .secondary) {
+                    exportBackup()
+                }
+                .disabled(isExporting || isBackingUpBlossom)
+
+                ActionButton(icon: "photo.stack", title: "Export Blossom", isLoading: isBackingUpBlossom, emphasis: .secondary) {
+                    exportBlossom()
+                }
+                .disabled(isExporting || isBackingUpBlossom)
+
+                #if os(macOS)
+                ActionButton(icon: "safari", title: "Open Browser", emphasis: .secondary) {
+                    if let url = URL(string: configService.config.webURL) {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+                #endif
             }
-            .padding(.horizontal)
+
+            // The wide layout left these live while the relay was stopped, and
+            // neither layout said why they were unavailable.
+            if !actionsAreEnabled {
+                Text("Start the relay to import or export.")
+                    .font(.appCaption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .disabled(!actionsAreEnabled)
+    }
+
+    private var actionsAreEnabled: Bool {
+        relayManager.isRunning || relayManager.isImporting
+    }
+
+    /// Export outcomes were rendered in the stacked layout only, so a failed
+    /// export on a wide macOS window produced no feedback at all.
+    @ViewBuilder
+    private var exportStatusView: some View {
+        if !exportStatusMessage.isEmpty {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: exportStatusIsError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                    .font(.appSystem(size: 11))
+                    .foregroundColor(exportStatusIsError ? .orange : .green)
+                Text(exportStatusMessage)
+                    .font(.appCaption)
+                    .foregroundColor(exportStatusIsError ? .primary : .secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .transition(.opacity)
         }
     }
 
     private var compactLogConsole: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Image(systemName: "terminal.fill")
-                    .font(.appSystem(size: 10, weight: .bold))
-                    .foregroundColor(.green)
-
-                Text("CONSOLE")
-                    .font(.appSystem(size: 10, weight: .bold, design: .monospaced))
-                    .foregroundColor(.secondary)
-
-                Spacer()
-
+            consoleHeader(title: "CONSOLE") {
                 Button {
                     showingFullLogs = true
                 } label: {
@@ -399,9 +379,6 @@ struct DashboardView: View {
                 }
                 .buttonStyle(.plain)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(Color.platformConsoleHeaderBackground)
 
             Divider()
                 .background(Color.platformCardBorder)
@@ -430,6 +407,8 @@ struct DashboardView: View {
                             .id(log.id)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel(Text("\(log.level): \(log.message)"))
                         }
                     }
                 }
@@ -473,9 +452,16 @@ struct DashboardView: View {
         return height
     }
     
+    private func setExportStatus(_ message: String, isError: Bool = false) {
+        withAnimation(Motion.fade) {
+            exportStatusMessage = message
+            exportStatusIsError = isError
+        }
+    }
+
     private func exportBackup() {
         isExporting = true
-        exportStatusMessage = "Preparing export..."
+        setExportStatus("Preparing export...")
 
         let tempDir = NSTemporaryDirectory()
         let tempPath = (tempDir as NSString).appendingPathComponent("haven-backup-\(Date().timeIntervalSince1970).zip")
@@ -485,9 +471,9 @@ struct DashboardView: View {
                 isExporting = false
 
                 guard success else {
-                    exportStatusMessage = "Export failed"
+                    setExportStatus("Export failed", isError: true)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        exportStatusMessage = ""
+                        setExportStatus("")
                     }
                     return
                 }
@@ -506,23 +492,23 @@ struct DashboardView: View {
                             try FileManager.default.removeItem(at: destURL)
                         }
                         try FileManager.default.moveItem(at: srcURL, to: destURL)
-                        exportStatusMessage = "Saved to \(destURL.lastPathComponent)"
+                        setExportStatus("Saved to \(destURL.lastPathComponent)")
                     } catch {
-                        exportStatusMessage = "Failed to save: \(error.localizedDescription)"
+                        setExportStatus("Failed to save: \(error.localizedDescription)", isError: true)
                     }
                 } else {
                     // User cancelled the save panel
-                    exportStatusMessage = "Export cancelled"
+                    setExportStatus("Export cancelled")
                     try? FileManager.default.removeItem(atPath: tempPath)
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                    exportStatusMessage = ""
+                    setExportStatus("")
                 }
                 #else
                 // iOS: Share the file
                 shareSheetURL = URL(fileURLWithPath: tempPath)
                 showingShareSheet = true
-                exportStatusMessage = "Ready to share"
+                setExportStatus("Ready to share")
                 #endif
             }
         }
@@ -530,7 +516,7 @@ struct DashboardView: View {
     
     private func exportBlossom() {
         isBackingUpBlossom = true
-        exportStatusMessage = "Preparing Blossom export..."
+        setExportStatus("Preparing Blossom export...")
 
         let tempDir = NSTemporaryDirectory()
         let tempPath = (tempDir as NSString).appendingPathComponent("blossom-backup-\(Date().timeIntervalSince1970).zip")
@@ -540,9 +526,9 @@ struct DashboardView: View {
                 isBackingUpBlossom = false
 
                 guard success else {
-                    exportStatusMessage = "Blossom export failed"
+                    setExportStatus("Blossom export failed", isError: true)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        exportStatusMessage = ""
+                        setExportStatus("")
                     }
                     return
                 }
@@ -561,22 +547,22 @@ struct DashboardView: View {
                             try FileManager.default.removeItem(at: destURL)
                         }
                         try FileManager.default.moveItem(at: srcURL, to: destURL)
-                        exportStatusMessage = "Saved to \(destURL.lastPathComponent)"
+                        setExportStatus("Saved to \(destURL.lastPathComponent)")
                     } catch {
-                        exportStatusMessage = "Failed to save: \(error.localizedDescription)"
+                        setExportStatus("Failed to save: \(error.localizedDescription)", isError: true)
                     }
                 } else {
-                    exportStatusMessage = "Export cancelled"
+                    setExportStatus("Export cancelled")
                     try? FileManager.default.removeItem(atPath: tempPath)
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                    exportStatusMessage = ""
+                    setExportStatus("")
                 }
                 #else
                 // iOS: Share the file
                 shareSheetURL = URL(fileURLWithPath: tempPath)
                 showingShareSheet = true
-                exportStatusMessage = "Ready to share"
+                setExportStatus("Ready to share")
                 #endif
             }
         }
@@ -772,76 +758,246 @@ struct DashboardView: View {
         }
     }
 
-    private var relayStatusHeader: some View {
-        let statusColor = relayManager.isBooting ? Color.yellow : (relayManager.isRunning && relayManager.isWotSyncing ? Color.orange : (relayManager.isRunning ? Color.green : Color.red))
-        return VStack(spacing: 16) {
-            HStack {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("RELAY STATUS")
-                        .font(.appSystem(size: 10, weight: .bold, design: .monospaced))
-                        .foregroundColor(.secondary.opacity(0.8))
+    // MARK: - Status header
 
-                    HStack(spacing: 12) {
-                        ZStack {
-                            Circle()
-                                .fill(statusColor.opacity(0.15))
-                                .frame(width: 24, height: 24)
-                                .scaleEffect(statusAnimate ? 1.3 : 1.0)
+    private var statusColor: Color {
+        if relayManager.isBooting { return .yellow }
+        guard relayManager.isRunning else { return .red }
+        return relayManager.isWotSyncing ? .orange : .green
+    }
 
-                            Circle()
-                                .stroke(statusColor.opacity(0.5), lineWidth: 1.5)
-                                .frame(width: 18, height: 18)
-                                .scaleEffect(statusAnimate ? 1.5 : 1.0)
-                                .opacity(statusAnimate ? 0.0 : 1.0)
+    private var statusTitle: String {
+        if relayManager.isBooting { return "BOOTING" }
+        guard relayManager.isRunning else { return "OFFLINE" }
+        // The dot has always turned orange during a web-of-trust sync, but the
+        // label said ONLINE in both branches — an unexplained colour change.
+        return relayManager.isWotSyncing ? "SYNCING" : "ONLINE"
+    }
 
-                            Circle()
-                                .fill(statusColor)
-                                .frame(width: 10, height: 10)
-                                .shadow(color: statusColor.opacity(0.8), radius: 4)
-                        }
+    /// Drives the halo and the expanding ring. `Motion.ambientPulse` is `nil`
+    /// under Reduce Motion, and `withAnimation(nil)` still *applies* the value —
+    /// so the guard has to sit on the assignment, not just the animation, or the
+    /// halo is stranded mid-pulse forever.
+    private func syncStatusPulse() {
+        guard relayManager.isRunning || relayManager.isBooting,
+              let pulse = Motion.ambientPulse else {
+            statusAnimate = false
+            return
+        }
+        guard !statusAnimate else { return }
+        withAnimation(pulse) { statusAnimate = true }
+    }
 
-                        Text(relayManager.isBooting ? "BOOTING..." : (relayManager.isRunning && relayManager.isWotSyncing ? "ONLINE" : (relayManager.isRunning ? "ONLINE" : "OFFLINE")))
-                             .font(.appSystem(size: 16, weight: .bold, design: .monospaced))
-                             .foregroundColor(.white)
+    private var statusIndicator: some View {
+        ZStack {
+            Circle()
+                .fill(statusColor.opacity(0.15))
+                .frame(width: 24, height: 24)
+                .scaleEffect(statusAnimate ? 1.3 : 1.0)
+
+            Circle()
+                .stroke(statusColor.opacity(0.5), lineWidth: 1.5)
+                .frame(width: 18, height: 18)
+                .scaleEffect(statusAnimate ? 1.5 : 1.0)
+                .opacity(statusAnimate ? 0.0 : 1.0)
+
+            Circle()
+                .fill(statusColor)
+                .frame(width: 10, height: 10)
+                .shadow(color: statusColor.opacity(0.8), radius: 4)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func uptimeText(since start: Date, now: Date) -> String {
+        let seconds = max(0, Int(now.timeIntervalSince(start)))
+        let days = seconds / 86_400
+        let hours = (seconds % 86_400) / 3_600
+        let minutes = (seconds % 3_600) / 60
+        if days > 0 { return "\(days)d \(hours)h" }
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+
+    private func liveMetaText(now: Date) -> String {
+        var parts: [String] = []
+        if let start = relayManager.startDate {
+            parts.append("up \(uptimeText(since: start, now: now))")
+        }
+        let count = relayManager.activeConnections
+        parts.append(count == 1 ? "1 connection" : "\(count) connections")
+        return parts.joined(separator: " · ")
+    }
+
+    private func copyRelayAddress() {
+        let address = configService.config.nostrURL
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(address, forType: .string)
+        #else
+        UIPasteboard.general.string = address
+        #endif
+        withAnimation(Motion.control) { didCopyAddress = true }
+        Task {
+            try? await Task.sleep(nanoseconds: 1_600_000_000)
+            withAnimation(Motion.control) { didCopyAddress = false }
+        }
+    }
+
+    /// The address the relay is actually reachable on. It lives in
+    /// `config.relayURL` / `config.relayPort` and used to appear nowhere on the
+    /// tab named after the relay — "Open Browser" was the only way to find it.
+    @ViewBuilder
+    private func relayAddressRow(showsMeta: Bool) -> some View {
+        if relayManager.isBooting && !relayManager.bootStatusMessage.isEmpty {
+            Text(relayManager.bootStatusMessage)
+                .font(.appSystem(size: 11))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+        } else {
+            HStack(spacing: 10) {
+                Button(action: copyRelayAddress) {
+                    HStack(spacing: 5) {
+                        Text(configService.config.nostrURL)
+                            .font(.appSystem(size: 11, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+
+                        Image(systemName: didCopyAddress ? "checkmark" : "doc.on.doc")
+                            .font(.appSystem(size: 9, weight: .semibold))
+                            .foregroundColor(didCopyAddress ? .green : .secondary.opacity(0.7))
                     }
                 }
+                .buttonStyle(.plain)
+                #if os(macOS)
+                .help(didCopyAddress ? "Copied" : "Copy the relay address")
+                #endif
+                .accessibilityLabel(Text("Relay address"))
+                .accessibilityValue(Text(configService.config.nostrURL))
+                .accessibilityHint(Text("Copies the address to the clipboard"))
 
-                Spacer()
+                if showsMeta {
+                    liveMeta
+                }
+            }
+        }
+    }
 
-                Button(action: {
-                    if relayManager.isRunning {
-                        relayManager.stopRelay {
-                            relayManager.startRelay(config: configService.config)
-                        }
-                    } else {
-                        relayManager.startRelay(config: configService.config)
-                    }
-                }) {
+    @ViewBuilder
+    private var liveMeta: some View {
+        if relayManager.isRunning {
+            TimelineView(.periodic(from: .now, by: 30)) { context in
+                Text(liveMetaText(now: context.date))
+                    .font(.appSystem(size: 11, design: .monospaced))
+                    .foregroundColor(.secondary.opacity(0.7))
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    private var relayControls: some View {
+        HStack(spacing: 8) {
+            // Stop was reachable from Settings and the menu bar but not from the
+            // screen named after the relay.
+            if relayManager.isRunning {
+                Button {
+                    relayManager.stopRelay()
+                } label: {
                     HStack(spacing: 6) {
-                        Image(systemName: relayManager.isRunning ? "arrow.clockwise" : "play.fill")
+                        Image(systemName: "stop.fill")
                             .font(.appSystem(size: 11, weight: .bold))
-                        Text(relayManager.isRunning ? "Restart Relay" : "Start Relay")
+                        Text("Stop")
                             .font(.appSystem(size: 12, weight: .bold))
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 16)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 14)
                     .padding(.vertical, 8)
-                    .background(
-                        LinearGradient(
-                            gradient: Gradient(colors: relayManager.isRunning
-                                ? [Color.orange.opacity(0.8), Color.orange.opacity(0.6)]
-                                : [Color.havenPurple, Color.havenPurpleDark]),
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
+                    .background(Color.platformCardBackground)
                     .cornerRadius(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.platformCardBorder, lineWidth: 1)
+                    )
                 }
                 .buttonStyle(.plain)
                 .disabled(relayManager.isBooting)
+                .accessibilityLabel(Text("Stop relay"))
+            }
+
+            Button {
+                if relayManager.isRunning {
+                    relayManager.stopRelay {
+                        relayManager.startRelay(config: configService.config)
+                    }
+                } else {
+                    relayManager.startRelay(config: configService.config)
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: relayManager.isRunning ? "arrow.clockwise" : "play.fill")
+                        .font(.appSystem(size: 11, weight: .bold))
+                    Text(relayManager.isRunning ? "Restart" : "Start Relay")
+                        .font(.appSystem(size: 12, weight: .bold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(
+                    LinearGradient(
+                        gradient: Gradient(colors: [Color.havenPurple, Color.havenPurpleDark]),
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .cornerRadius(8)
+                .opacity(relayManager.isBooting ? 0.4 : 1.0)
+            }
+            .buttonStyle(.plain)
+            .disabled(relayManager.isBooting)
+            .accessibilityLabel(Text(relayManager.isRunning ? "Restart relay" : "Start relay"))
+        }
+    }
+
+    /// `isCompact` stacks the controls under the status block. The one-row form
+    /// needs roughly 420pt before the address starts truncating, which is wider
+    /// than the 380pt sidebar rail.
+    private func relayStatusHeader(isCompact: Bool) -> some View {
+        VStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .center, spacing: 14) {
+                    statusIndicator
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(statusTitle)
+                            .font(.appSystem(size: 16, weight: .bold, design: .monospaced))
+                            .foregroundColor(.white)
+                            .accessibilityLabel(Text("Relay status"))
+                            .accessibilityValue(Text(statusTitle))
+
+                        relayAddressRow(showsMeta: !isCompact)
+
+                        if isCompact {
+                            liveMeta
+                        }
+                    }
+                    .accessibilityElement(children: .contain)
+
+                    Spacer(minLength: 12)
+
+                    if !isCompact {
+                        relayControls
+                    }
+                }
+
+                if isCompact {
+                    relayControls
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 12)
                     .fill(Color.platformCardBackground)
@@ -862,14 +1018,15 @@ struct DashboardView: View {
                     )
             )
             .shadow(color: statusColor.opacity(relayManager.isRunning && !relayManager.isBooting ? 0.08 : 0), radius: 10, x: 0, y: 4)
-            
+            .animation(Motion.toggle, value: relayManager.isRunning)
+
             // Error recovery banner
             if relayManager.isLocked || relayManager.isPortConflict {
                 VStack(spacing: 12) {
                     HStack(spacing: 8) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundColor(.orange)
-                        Text(relayManager.isPortConflict ? "Port 3355 is already in use" : "Database lock detected")
+                        Text(relayManager.isPortConflict ? "Port \(configService.config.relayPort) is already in use" : "Database lock detected")
                             .font(.appSystem(size: 13, weight: .medium))
                             .foregroundColor(.primary)
                         Spacer()
@@ -922,5 +1079,9 @@ struct DashboardView: View {
             }
         }
         .padding(.horizontal)
+        .onAppear { syncStatusPulse() }
+        .onChange(of: relayManager.isRunning) { _, _ in syncStatusPulse() }
+        .onChange(of: relayManager.isBooting) { _, _ in syncStatusPulse() }
     }
+
 }


### PR DESCRIPTION
Addresses the Relay tab review in the `nostr-vault-mac` channel.

## Fixed

| | |
|---|---|
| **Dead status pulse** | `statusAnimate` was declared, read by two of the three circles in the indicator, and assigned nowhere in the app. Now driven by `Motion.ambientPulse`, with the Reduce Motion guard on the assignment rather than the animation — `withAnimation(nil)` still applies the value. |
| **Silent export failures on macOS** | `exportStatusMessage` was set on every path including failure and rendered only in the stacked layout. A failed export on a wide window gave no feedback. Shared now, and failure looks different from success. |
| **Unexplained orange dot** | The dot went orange during a web-of-trust sync while the label said ONLINE in both branches. It says SYNCING. |
| **No Stop control** | `stopRelay` was reachable from Settings and the menu bar but not from the Relay tab. Added beside Restart. |

## Redesigned

- **The header shows the relay's address.** `config.nostrURL` with click-to-copy, plus uptime and connection count — `startDate` and `activeConnections` were already published and displayed nowhere. Under 480pt the controls stack below the status block.
- **Four stat cards → two.** Storage Used / Blossom Storage / Media Cache were three views of one number. The storage breakdown already splits the total three ways; its Blossom and Media Cache rows now drill into the detail views those cards opened, so no route is lost.
- **Console gets the height.** The wide layout's full-width stats band moved into the 380pt rail.
- **Action hierarchy.** `ActionButton` takes an `Emphasis`; exports and Open Browser are tinted, not filled (7.8:1 contrast). Disabled buttons look disabled, and both layouts now disable them consistently and say why.
- **Removed the fake window buttons** from the console header.
- **Accessibility**: the tab had zero modifiers. Status, stat cards, action buttons and log lines now have labels and values.

## Verification

- macOS and iOS targets build.
- Header and left rail checked through `ImageRenderer` at 360 / 470 / 760 / 1100pt, offline and running, with local and long remote hostnames — no overflow or clipping.
- **Not** exercised in the running app: a second instance would have collided with the live relay's port and BadgerDB lock. Worth a manual pass on the tab before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
