### PR TITLE
fix: private-key reveal fails open when device-owner auth is unavailable

### DIFF
--- a/HavenApp/HavenApp/Views/SettingsView.swift
+++ b/HavenApp/HavenApp/Views/SettingsView.swift
@@ -1056,19 +1056,19 @@ struct AccountDetailView: View {
     }
 
     private func authenticateAndReveal() {
+        // Fail CLOSED: reveal the private key only after a successful device-owner
+        // authentication (Face/Touch ID, or passcode fallback). The previous code
+        // revealed the key with NO authentication when no biometry/passcode was
+        // enrolled or LAContext errored — a fail-open leak of the signing key.
+        // When auth is unavailable, evaluatePolicy calls back success=false, so we
+        // simply don't reveal.
         let context = LAContext()
-        var error: NSError?
-
-        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to reveal your private key") { success, _ in
-                DispatchQueue.main.async {
-                    if success {
-                        onRevealKey()
-                    }
+        context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate to reveal your private key") { success, _ in
+            DispatchQueue.main.async {
+                if success {
+                    onRevealKey()
                 }
             }
-        } else {
-            onRevealKey()
         }
     }
 


### PR DESCRIPTION
Master still reveals the nsec with **no authentication** when `canEvaluatePolicy` returns false — no passcode/biometry enrolled, or any LAContext error:

```swift
} else {
    onRevealKey()   // SettingsView.swift:1070-1071 on master
}
```

The fix (cherry-pick of `90d85a8`, which has been sitting unmerged on `perf/feed-hotpath-and-linkpreview` since Aug 3) drops the branch and reveals only from `evaluatePolicy`s success callback. When device-owner auth is unavailable the callback reports failure, so it fails closed.

Trade-off, deliberate: on a device with no passcode set at all, Reveal Private Key now does nothing rather than printing the key.

Android was checked and is not affected — `authenticateAndReveal` only fires on `onAuthenticationSucceeded`, and `MainActivity` really is a `FragmentActivity` so the unauthenticated `activity == null` fallback in AccountSettingsScreen.kt:349 is unreachable today (still worth deleting).

One file, 10 lines.