### PR TITLE
Android: confirm before paying an invoice, and show the amount first

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/service/LiveChatService.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/service/LiveChatService.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.nostrvault.data.local.ConfigStore
 import com.nostrvault.data.model.LiveStream
 import com.nostrvault.data.remote.WebSocketClient
+import com.nostrvault.util.Bolt11
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -43,9 +44,6 @@ class LiveChatService @Inject constructor(
         const val CHAT_KIND = 1311
         private const val ZAP_RECEIPT_KIND = 9735
         private const val BACKLOG = 100
-
-        /** `lnbc<amount><multiplier>1…` — the amount lives in the prefix. */
-        private val BOLT11_PREFIX = Regex("""^ln(?:bc|tb|bcrt)(\d+)([munp]?)1""")
 
         /**
          * Fallback chat relays, for a stream that names none of its own.
@@ -98,24 +96,10 @@ class LiveChatService @Inject constructor(
      * and all 12 carried a bolt11 whose prefix gives the number —
      * `lnbc330n…` is 330 nano-BTC, which is 33 sats.
      *
-     * Integer msat throughout: in floating point 90n comes out as
-     * 9.000000000000002 sats.
+     * The parsing itself moved to [Bolt11] when the wallet needed the same
+     * reading before a payment confirmation.
      */
-    internal fun satsFromBolt11(invoice: String): Long? {
-        val match = BOLT11_PREFIX.find(invoice.trim().lowercase()) ?: return null
-        val amount = match.groupValues[1].toLongOrNull() ?: return null
-        // 1 BTC = 100_000_000_000 msat.
-        val msat = when (match.groupValues[2]) {
-            "m" -> amount * 100_000_000L
-            "u" -> amount * 100_000L
-            "n" -> amount * 100L
-            // pico-BTC is a tenth of a msat; a valid pico amount is a multiple of 10.
-            "p" -> amount / 10L
-            "" -> amount * 100_000_000_000L
-            else -> return null
-        }
-        return (msat / 1000L).takeIf { it > 0 }
-    }
+    internal fun satsFromBolt11(invoice: String): Long? = Bolt11.satsOrNull(invoice)
 
     /**
      * Relays to talk to, most authoritative first: the stream's own `relays`

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/DestructiveConfirmDialog.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/DestructiveConfirmDialog.kt
@@ -1,0 +1,50 @@
+package com.nostrvault.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import com.nostrvault.ui.theme.ErrorRed
+
+/**
+ * One confirmation treatment for every action that cannot be undone.
+ *
+ * The shape of the question is fixed rather than left to each call site:
+ *
+ * - the **title** repeats the button that opened it, so you can tell which
+ *   control you actually hit;
+ * - the **consequence** is one plain sentence about what you lose, and it
+ *   carries the amount whenever money moves — a payment confirmation that
+ *   does not show the number is not a confirmation, since a bolt11 string is
+ *   opaque;
+ * - **Cancel is the easy way out**: back gesture and outside tap both dismiss,
+ *   and the destructive verb is the only thing that commits.
+ *
+ * Mirrors `confirmDestructive` on the Swift side.
+ *
+ * @param confirmLabel the destructive verb. Not "OK".
+ */
+@Composable
+fun DestructiveConfirmDialog(
+    title: String,
+    consequence: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    cancelLabel: String = "Cancel",
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(consequence) },
+        confirmButton = {
+            TextButton(onClick = {
+                onDismiss()
+                onConfirm()
+            }) { Text(confirmLabel, color = ErrorRed) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(cancelLabel) }
+        },
+    )
+}

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/wallet/WalletLightningTab.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/wallet/WalletLightningTab.kt
@@ -15,12 +15,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.nostrvault.ui.components.DestructiveConfirmDialog
 import com.nostrvault.ui.screens.WalletCaption
 import com.nostrvault.ui.screens.WalletQr
 import com.nostrvault.ui.screens.WalletSectionLabel
 import com.nostrvault.ui.screens.WalletViewModel
 import com.nostrvault.ui.screens.walletFieldColors
 import com.nostrvault.ui.theme.*
+import com.nostrvault.util.Bolt11
+import com.nostrvault.util.Bolt11Amount
 
 /**
  * Lightning (NWC) tab: balance, receive (create invoice + QR) and send (pay bolt11).
@@ -48,6 +51,14 @@ fun WalletLightningTab(viewModel: WalletViewModel) {
     var receiveAmount by remember { mutableStateOf("") }
     var receiveDesc by remember { mutableStateOf("") }
     var sendInvoice by remember { mutableStateOf("") }
+    var showPayConfirm by remember { mutableStateOf(false) }
+
+    // Decoded on every edit, so the amount is on screen before the button is,
+    // not only inside the confirmation. A bolt11 string says nothing at a
+    // glance.
+    val pastedAmount = remember(sendInvoice) {
+        Bolt11.amount(sendInvoice.trim())
+    }
 
     Column(
         modifier = Modifier
@@ -130,9 +141,26 @@ fun WalletLightningTab(viewModel: WalletViewModel) {
             minLines = 2,
             colors = walletFieldColors(colors.primary),
         )
+        if (sendInvoice.isNotBlank()) {
+            Spacer(Modifier.height(8.dp))
+            when (pastedAmount) {
+                is Bolt11Amount.Sats -> Text(
+                    "Paying ${formatSats(pastedAmount.sats)} sats",
+                    color = colors.primary, fontSize = 14.sp, fontWeight = FontWeight.SemiBold,
+                )
+                Bolt11Amount.Unspecified -> Text(
+                    "This invoice names no amount — your wallet decides what to send, and may refuse it.",
+                    color = SecondaryText, fontSize = 12.sp,
+                )
+                Bolt11Amount.Unreadable -> Text(
+                    "Not an invoice this app can read. Check it before you pay.",
+                    color = SecondaryText, fontSize = 12.sp,
+                )
+            }
+        }
         Spacer(Modifier.height(12.dp))
         Button(
-            onClick = { viewModel.payInvoice(sendInvoice); sendInvoice = "" },
+            onClick = { showPayConfirm = true },
             enabled = !busy && sendInvoice.isNotBlank(),
             colors = ButtonDefaults.buttonColors(containerColor = colors.primary),
             modifier = Modifier.fillMaxWidth(),
@@ -141,4 +169,28 @@ fun WalletLightningTab(viewModel: WalletViewModel) {
         WalletCaption("Payments use your connected NWC wallet.")
         Spacer(Modifier.height(32.dp))
     }
+
+    if (showPayConfirm) {
+        DestructiveConfirmDialog(
+            title = "Pay Invoice",
+            consequence = when (pastedAmount) {
+                is Bolt11Amount.Sats ->
+                    "This sends ${formatSats(pastedAmount.sats)} sats from your wallet. " +
+                        "Lightning payments cannot be reversed."
+                Bolt11Amount.Unspecified ->
+                    "This invoice names no amount, so your wallet decides what to send — " +
+                        "and it may refuse it outright. Lightning payments cannot be reversed."
+                Bolt11Amount.Unreadable ->
+                    "Nostr Vault cannot read this invoice, so it cannot tell you what it will " +
+                        "cost. Your wallet will pay whatever it says. Lightning payments cannot " +
+                        "be reversed."
+            },
+            confirmLabel = "Pay",
+            onConfirm = { viewModel.payInvoice(sendInvoice); sendInvoice = "" },
+            onDismiss = { showPayConfirm = false },
+        )
+    }
 }
+
+/** 21000 reads as 21,000 — the digit group is the point of showing it. */
+private fun formatSats(sats: Long): String = "%,d".format(sats)

--- a/NostrVault/app/src/main/java/com/nostrvault/util/Bolt11.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/util/Bolt11.kt
@@ -1,0 +1,68 @@
+package com.nostrvault.util
+
+/**
+ * What a BOLT-11 invoice says it will cost.
+ *
+ * The distinction between "no amount" and "cannot read it" matters at a
+ * payment confirmation: the first is a legal invoice where the payer's wallet
+ * chooses the number, the second is a string this app cannot vouch for. Both
+ * used to collapse into `null`, which is fine for displaying a zap receipt and
+ * useless for warning someone before they spend.
+ */
+sealed interface Bolt11Amount {
+    data class Sats(val sats: Long) : Bolt11Amount
+
+    /** A valid invoice that names no amount — the paying wallet decides. */
+    data object Unspecified : Bolt11Amount
+
+    /** Not an invoice this app can read. */
+    data object Unreadable : Bolt11Amount
+}
+
+/**
+ * Reads the amount out of the human-readable part of a BOLT-11 invoice.
+ *
+ * Integer msat throughout: in floating point 90n comes out as
+ * 9.000000000000002 sats.
+ *
+ * Reading only. An invoice this app cannot parse is still payable — the wallet
+ * on the other end is the authority on that, not us — so callers should warn
+ * rather than block.
+ */
+object Bolt11 {
+
+    /**
+     * `lnbc330n1…` is 330 nano-BTC, which is 33 sats. The trailing `1` is the
+     * bech32 separator, and the regex backtracks onto it: in `lnbc11p…` the
+     * amount is 1 BTC and the second `1` separates, not 11 pico-BTC.
+     *
+     * One ambiguity this cannot resolve without full bech32 validation: a
+     * malformed multiplier (`lnbc1a1…`) backtracks to the same shape as a
+     * genuinely amountless invoice, so it reads as [Bolt11Amount.Unspecified].
+     * Both end the same way — the wallet is asked and decides.
+     */
+    private val PREFIX = Regex("""^ln(?:bc|tb|bcrt)(\d*)([munp]?)1""")
+
+    fun amount(invoice: String): Bolt11Amount {
+        val match = PREFIX.find(invoice.trim().lowercase()) ?: return Bolt11Amount.Unreadable
+        val digits = match.groupValues[1]
+        if (digits.isEmpty()) return Bolt11Amount.Unspecified
+
+        val value = digits.toLongOrNull() ?: return Bolt11Amount.Unreadable
+        // 1 BTC = 100_000_000_000 msat.
+        val msat = when (match.groupValues[2]) {
+            "m" -> value * 100_000_000L
+            "u" -> value * 100_000L
+            "n" -> value * 100L
+            // pico-BTC is a tenth of a msat; a valid pico amount is a multiple of 10.
+            "p" -> value / 10L
+            "" -> value * 100_000_000_000L
+            else -> return Bolt11Amount.Unreadable
+        }
+        return Bolt11Amount.Sats(msat / 1000L)
+    }
+
+    /** Sats, or null when the invoice names no readable positive amount. */
+    fun satsOrNull(invoice: String): Long? =
+        (amount(invoice) as? Bolt11Amount.Sats)?.sats?.takeIf { it > 0 }
+}

--- a/NostrVault/app/src/test/java/com/nostrvault/util/Bolt11Test.kt
+++ b/NostrVault/app/src/test/java/com/nostrvault/util/Bolt11Test.kt
@@ -1,0 +1,57 @@
+package com.nostrvault.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The wallet's payment confirmation reads its number from here, so the
+ * distinction between "no amount" and "cannot read it" is the part that
+ * matters — those two get different warnings, and neither may be reported as
+ * a quantity.
+ *
+ * Amount vectors are the ones from [com.nostrvault.service.Bolt11AmountTest],
+ * which came off real nos.lol zap receipts.
+ */
+class Bolt11Test {
+
+    @Test fun `an amount is read as sats`() {
+        assertEquals(Bolt11Amount.Sats(21L), Bolt11.amount("lnbc210n1p4fakabc"))
+        assertEquals(Bolt11Amount.Sats(33L), Bolt11.amount("lnbc330n1p4fakabc"))
+        assertEquals(Bolt11Amount.Sats(100_000L), Bolt11.amount("lnbc1m1p4fakabc"))
+        assertEquals(Bolt11Amount.Sats(100L), Bolt11.amount("lnbc1u1p4fakabc"))
+        // No multiplier at all: whole BTC. The second `1` is the bech32
+        // separator, not part of an "11 pico" amount.
+        assertEquals(Bolt11Amount.Sats(100_000_000L), Bolt11.amount("lnbc11p4fakabc"))
+    }
+
+    @Test fun `awkward amounts stay whole numbers`() {
+        // In floating point these come out as 9.000000000000002 and
+        // 7.000000000000001.
+        assertEquals(Bolt11Amount.Sats(9L), Bolt11.amount("lnbc90n1p4fakabc"))
+        assertEquals(Bolt11Amount.Sats(7L), Bolt11.amount("lnbc70n1p4fakabc"))
+        assertEquals(Bolt11Amount.Sats(1L), Bolt11.amount("lnbc10n1p4fakabc"))
+    }
+
+    @Test fun `an amountless invoice is not an unreadable one`() {
+        // Legal, and the payer's wallet chooses. Warned about, not blocked.
+        assertEquals(Bolt11Amount.Unspecified, Bolt11.amount("lnbc1p4fakabc"))
+        assertEquals(Bolt11Amount.Unspecified, Bolt11.amount("lntb1p4fakabc"))
+    }
+
+    @Test fun `a string that is not an invoice is unreadable`() {
+        assertEquals(Bolt11Amount.Unreadable, Bolt11.amount("not-an-invoice"))
+        assertEquals(Bolt11Amount.Unreadable, Bolt11.amount(""))
+        // No bech32 separator after the human-readable part.
+        assertEquals(Bolt11Amount.Unreadable, Bolt11.amount("lnbc330n"))
+    }
+
+    @Test fun `case and whitespace do not matter`() {
+        assertEquals(Bolt11Amount.Sats(21L), Bolt11.amount("  LNBC210N1P4FAKABC  "))
+    }
+
+    @Test fun `satsOrNull reports nothing rather than zero`() {
+        assertEquals(21L, Bolt11.satsOrNull("lnbc210n1p4fakabc"))
+        assertEquals(null, Bolt11.satsOrNull("lnbc1p4fakabc"))
+        assertEquals(null, Bolt11.satsOrNull("not-an-invoice"))
+    }
+}


### PR DESCRIPTION
Closes the Android "Pay Invoice spends on one tap" task.

## The problem

A pasted bolt11 string is opaque, and the only thing between it and a spend was a full-width primary button. The amount was never on screen at any point.

## What changed

- The invoice is **decoded as it is typed**, so the amount sits under the field before you reach the button.
- A **confirmation** restates it. `DestructiveConfirmDialog` is the Compose counterpart of `confirmDestructive` from #12: title repeats the button you pressed, message is one plain sentence about what you lose and carries the amount, cancelling is the easy way out (back gesture and outside tap both dismiss).
- An **amountless** invoice and an **unreadable** one now get different warnings instead of both showing nothing. Neither is blocked — the wallet is the authority on what it will pay, not us.

## `util/Bolt11`

The parse moved out of `LiveChatService` into a shared util, keeping its msat-integer reading (in floating point 90n comes out as 9.000000000000002 sats) and adding the amountless/unreadable distinction the confirmation needs. `LiveChatService.satsFromBolt11` delegates, so its existing real-invoice vectors still cover the shared path.

**`ZapService` holds a third copy** of this parse, and its nano and pico cases truncate (`amount / 10` rather than integer msat). Left alone — changing what a zap receipt displays is not this task, but it should be folded into `Bolt11` at some point.

## Not applicable on Android

The iOS "Forget an unclaimed ecash token" path has no Android equivalent — `WalletCashuTab.kt` has no unclaimed-token list at all. Nothing to confirm there yet.

## Verification

- `./gradlew testReleaseUnitTest` — **65 tests, 9 suites, 0 failures**, including 6 new `Bolt11Test` cases and the 5 existing `Bolt11AmountTest` vectors still passing through the delegate.
- Release Kotlin compiles clean (`compileReleaseKotlin`), which covers the changed Compose code.

**Not verified:** I have not run this on a device, so I have not watched the dialog appear or checked the amount line against a real invoice in the field. Worth one pass with a real bolt11 and a zero-amount one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)