### PR TITLE
macOS+iOS: Notes pane — search, Show more, hover, quoted-card visibility

### DIFF
--- a/HavenApp/HavenApp/Views/Components/QuotedNoteView.swift
+++ b/HavenApp/HavenApp/Views/Components/QuotedNoteView.swift
@@ -31,11 +31,13 @@ struct QuotedNoteView: View {
         .background(Color.platformTertiaryGroupedBackground)
         .cornerRadius(8)
         .overlay(
+            // The fill step alone (tertiary sitting on the note card's secondary)
+            // is 1.10-1.22:1 — a seam, not a boundary — and the old purple accent
+            // stroke it wore instead only reached 1.17-1.55:1. `borderStrong` is
+            // the ramp's token for exactly this: a border that is the only real
+            // cue a card is nested inside another. 3.16-3.22:1 here.
             RoundedRectangle(cornerRadius: 8)
-                .stroke(
-                    Color.havenPurple.opacity(ConfigService.shared.config.useOLED ? 0.30 : 0.12),
-                    lineWidth: ConfigService.shared.config.useOLED ? 1.2 : 0.5
-                )
+                .stroke(Color.borderStrong, lineWidth: 1)
         )
     }
     

--- a/HavenApp/HavenApp/Views/Vault/VaultModeLists.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultModeLists.swift
@@ -120,6 +120,10 @@ extension VaultView {
                                 reposterPubkeys: showEngagement ? repostMap[event.id] : nil,
                                 quoterPubkeys: showEngagement ? quoteMap[event.id] : nil
                             )
+                            // Likes and Zaps rows carry this same inset; Notes rows
+                            // were flush to the pane edges, the one filter that read
+                            // differently from the other two.
+                            .padding(.horizontal, 16)
                         }
                         .buttonStyle(.plain)
                         #else
@@ -132,6 +136,7 @@ extension VaultView {
                             reposterPubkeys: showEngagement ? repostMap[event.id] : nil,
                             quoterPubkeys: showEngagement ? quoteMap[event.id] : nil
                         )
+                        .padding(.horizontal, 16)
                         .contentShape(Rectangle())
                         .onTapGesture {
                             self.openNote(event.id)

--- a/HavenApp/HavenApp/Views/Vault/VaultNoteRow.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultNoteRow.swift
@@ -1,5 +1,18 @@
 import SwiftUI
 
+/// Measures a note body's fully unclamped height so `truncate` can tell
+/// whether its `lineLimit` actually cut anything, rather than guessing from
+/// character count.
+private struct FullTextHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+private struct ClampedTextHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
 struct NoteRow: View {
     let event: NostrEvent
     /// When true, clamp the body to a few lines and append a "Show more"
@@ -21,6 +34,16 @@ struct NoteRow: View {
     @State private var showingReposters = false
     @State private var showingQuoters = false
     @State private var isExpanded = false
+    // "Show more" used to key off `cleanContent.count > 240` — a proxy that
+    // disagreed with the real 8-line clamp in both directions: a short note
+    // with several newlines could wrap past 8 lines with no button, and a
+    // long one-paragraph note under the char threshold... no, over it but
+    // still fitting in 8 lines got a button that revealed nothing new.
+    // These track the note's actual rendered height clamped vs. unclamped,
+    // so the button only appears when the clamp is actually cutting text.
+    @State private var clampedContentHeight: CGFloat = 0
+    @State private var fullContentHeight: CGFloat = 0
+    private var isContentClamped: Bool { fullContentHeight > clampedContentHeight + 1 }
 
     var cleanContent: String {
         return event.content.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -216,6 +239,7 @@ struct NoteRow: View {
             ZStack {
                 Color.platformSecondaryGroupedBackground
                 Color.havenPurple.opacity(0.015)
+                Color.white.opacity(isHovered ? 0.04 : 0)
             }
         )
         .cornerRadius(10)
@@ -231,6 +255,11 @@ struct NoteRow: View {
                 )
         )
         .contentShape(Rectangle())
+        .animation(Motion.control, value: isHovered)
+        #if os(iOS)
+        .hoverEffect(.lift)
+        #endif
+        .onHover { isHovered = $0 }
     }
 
     // MARK: - Expanded Layout
@@ -301,14 +330,41 @@ struct NoteRow: View {
                 let links = event.linkURLs
 
                 if !cleanContent.isEmpty {
-                    Text(NostrContentFormatter.format(cleanContent, mediaURLs: urls))
-                        .font(.appSystem(size: contentFontSize, weight: .regular, design: .default))
-                        .foregroundColor(Color(red: 1, green: 1, blue: 1))
-                        .lineSpacing(2)
-                        .lineLimit(truncate && !isExpanded ? 8 : nil)
-                        .fixedSize(horizontal: false, vertical: true)
+                    let formattedContent = NostrContentFormatter.format(cleanContent, mediaURLs: urls)
+                    Group {
+                        if truncate {
+                            Text(formattedContent)
+                                .font(.appSystem(size: contentFontSize, weight: .regular, design: .default))
+                                .foregroundColor(Color(red: 1, green: 1, blue: 1))
+                                .lineSpacing(2)
+                                .lineLimit(isExpanded ? nil : 8)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .background(
+                                    Text(formattedContent)
+                                        .font(.appSystem(size: contentFontSize, weight: .regular, design: .default))
+                                        .lineSpacing(2)
+                                        .lineLimit(nil)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .hidden()
+                                        .background(GeometryReader { geo in
+                                            Color.clear.preference(key: FullTextHeightKey.self, value: geo.size.height)
+                                        })
+                                )
+                                .background(GeometryReader { geo in
+                                    Color.clear.preference(key: ClampedTextHeightKey.self, value: geo.size.height)
+                                })
+                                .onPreferenceChange(FullTextHeightKey.self) { fullContentHeight = $0 }
+                                .onPreferenceChange(ClampedTextHeightKey.self) { clampedContentHeight = $0 }
+                        } else {
+                            Text(formattedContent)
+                                .font(.appSystem(size: contentFontSize, weight: .regular, design: .default))
+                                .foregroundColor(Color(red: 1, green: 1, blue: 1))
+                                .lineSpacing(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
 
-                    if truncate && !isExpanded && cleanContent.count > 240 {
+                    if truncate && !isExpanded && isContentClamped {
                         Button(action: { withAnimation(Motion.panel) { isExpanded = true } }) {
                             Text("Show more")
                                 .font(.appSystem(size: 12, weight: .semibold, design: .monospaced))
@@ -360,6 +416,10 @@ struct NoteRow: View {
             ZStack {
                 Color.platformSecondaryGroupedBackground
                 Color.havenPurple.opacity(0.015)
+                // Zero mouse feedback on the app's densest, most-clicked element —
+                // `isHovered` was tracked and never read. Same tint level as
+                // ProfileResultRow's hover state, for one hover language app-wide.
+                Color.white.opacity(isHovered ? 0.04 : 0)
             }
         )
         .cornerRadius(12)
@@ -372,9 +432,11 @@ struct NoteRow: View {
                 )
         )
         .contentShape(RoundedRectangle(cornerRadius: 12))
+        .animation(Motion.control, value: isHovered)
         #if os(iOS)
         .hoverEffect(.lift)
         #endif
+        .onHover { isHovered = $0 }
         .clipped()
     }
 
@@ -480,8 +542,11 @@ struct NoteRow: View {
                                 .foregroundColor(.secondary.opacity(0.6))
                         }
                     }
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("\(uniqueReactors.count) reaction\(uniqueReactors.count == 1 ? "" : "s")")
             }
 
             // Reposts
@@ -505,8 +570,11 @@ struct NoteRow: View {
                             .font(.appSystem(size: 11, weight: .semibold, design: .monospaced))
                             .foregroundColor(.green.opacity(0.8))
                     }
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("\(uniqueReposters.count) repost\(uniqueReposters.count == 1 ? "" : "s")")
             }
 
             // Quotes
@@ -530,8 +598,11 @@ struct NoteRow: View {
                             .font(.appSystem(size: 11, weight: .semibold, design: .monospaced))
                             .foregroundColor(.blue.opacity(0.8))
                     }
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("\(uniqueQuoters.count) quote\(uniqueQuoters.count == 1 ? "" : "s")")
             }
 
             // Zaps
@@ -552,6 +623,8 @@ struct NoteRow: View {
                         .font(.appSystem(size: 11, weight: .semibold, design: .monospaced))
                         .foregroundColor(.orange.opacity(0.8))
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Zapped \(Self.formatSats(totalSats)) by \(uniqueZapperPubkeys.count) \(uniqueZapperPubkeys.count == 1 ? "person" : "people")")
             }
 
             Spacer()

--- a/HavenApp/HavenApp/Views/Vault/VaultToolbar.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultToolbar.swift
@@ -164,15 +164,100 @@ extension VaultView {
         .overlay(RoundedRectangle(cornerRadius: 20).stroke(Color(red: 0.2, green: 0.2, blue: 0.25), lineWidth: 0.8))
     }
 
+    // `ModeButton` (labeled, filled-pill-when-selected) is the language for
+    // *navigation*: which of Notes/Likes/Zaps you're looking at. This is a
+    // display option, not a destination, so it used to read as a fourth mode
+    // sitting in the same row — `IconFilterButton` is the icon-only language
+    // the rest of the toolbar already uses for exactly that distinction (see
+    // `trailingToolbarInline`'s condensed-view toggle on iOS).
     var compactToggleButton: some View {
-        ModeButton(
-            title: "Compact",
-            icon: "rectangle.compress.vertical",
-            isSelected: noteLayoutMode == .compact
+        IconFilterButton(
+            icon: noteLayoutMode == .compact ? "rectangle.expand.vertical" : "rectangle.compress.vertical",
+            tooltip: noteLayoutMode == .compact ? "Expanded View" : "Condensed View",
+            isSelected: noteLayoutMode == .compact,
+            color: .havenPurple
         ) {
             withAnimation(Motion.toggle) {
                 noteLayoutMode = noteLayoutMode == .compact ? .expanded : .compact
             }
+        }
+    }
+
+    // MARK: - Search
+
+    /// The one control that opens the pane's search — `committedSearch` and
+    /// `searchScope` already drove real filtering (`applySearchFilter`,
+    /// `profileSearchResults`) with nothing anywhere in the UI that could set
+    /// them.
+    var searchToggleButton: some View {
+        IconFilterButton(
+            icon: isSearchActive ? "xmark" : "magnifyingglass",
+            tooltip: isSearchActive ? "Close Search" : "Search",
+            isSelected: isSearchActive,
+            color: .havenPurple
+        ) {
+            withAnimation(Motion.toggle) {
+                isSearchActive.toggle()
+                if !isSearchActive {
+                    searchQueryDraft = ""
+                    committedSearch = ""
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    var searchBar: some View {
+        if isSearchActive {
+            HStack(spacing: 8) {
+                Menu {
+                    ForEach(SearchScope.allCases, id: \.self) { scope in
+                        Button {
+                            searchScope = scope
+                        } label: {
+                            Label(scope.label, systemImage: scope.icon)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: searchScope.icon)
+                        Image(systemName: "chevron.down")
+                            .font(.appSystem(size: 8, weight: .bold))
+                    }
+                    .font(.appSystem(size: 13, weight: .semibold))
+                    .foregroundColor(.havenPurple)
+                }
+                #if os(macOS)
+                .menuStyle(.borderlessButton)
+                #endif
+                .fixedSize()
+                .accessibilityLabel("Search scope: \(searchScope.label)")
+
+                TextField("Search \(searchScope.label.lowercased())", text: $searchQueryDraft)
+                    .textFieldStyle(.plain)
+                    .font(.appSystem(size: 14))
+                    .onSubmit {
+                        committedSearch = searchQueryDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                    }
+
+                if !searchQueryDraft.isEmpty {
+                    Button {
+                        searchQueryDraft = ""
+                        committedSearch = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color(red: 0.15, green: 0.15, blue: 0.2))
+            .cornerRadius(8)
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color(red: 0.2, green: 0.2, blue: 0.25), lineWidth: 0.8))
+            .transition(.opacity.combined(with: .move(edge: .top)))
         }
     }
 

--- a/HavenApp/HavenApp/Views/Vault/VaultView.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultView.swift
@@ -11,6 +11,10 @@ struct VaultView: View {
     @State var navigationPath = NavigationPath()
     @State var committedSearch = ""
     @State var searchScope: SearchScope = .notes
+    /// Whether the search field is showing. `committedSearch` had no control
+    /// anywhere that ever set it — the entire search feature was unreachable.
+    @State var isSearchActive = false
+    @State var searchQueryDraft = ""
     @State var displayProfileResults: [FeedProfile] = []
     @State var viewMode: ViewMode = .notes
 
@@ -570,8 +574,11 @@ struct VaultView: View {
                     zapsFilterView
                 }
 
+                searchToggleButton
                 compactToggleButton
             }
+
+            searchBar
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal)
@@ -590,6 +597,7 @@ struct VaultView: View {
                     HStack {
                         modeView
                         Spacer()
+                        searchToggleButton
                     }
                     if viewMode == .notes {
                         ScrollView(.horizontal, showsIndicators: false) {
@@ -604,19 +612,24 @@ struct VaultView: View {
                             zapsFilterView
                         }
                     }
+                    searchBar
                 }
             } else {
-                HStack {
-                    modeView
-                    Spacer()
-                    if viewMode == .notes {
-                        filterView
-                    } else if viewMode == .likes {
-                        likesFilterView
-                    } else if viewMode == .zaps {
-                        zapsFilterView
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack {
+                        modeView
+                        Spacer()
+                        if viewMode == .notes {
+                            filterView
+                        } else if viewMode == .likes {
+                            likesFilterView
+                        } else if viewMode == .zaps {
+                            zapsFilterView
+                        }
+                        searchToggleButton
+                        compactToggleButton
                     }
-                    compactToggleButton
+                    searchBar
                 }
             }
             #endif


### PR DESCRIPTION
## Summary
From the Notes-pane audit (`RESEARCH/macos-ui-audit/06-vault-notes.md`):

- **Search was entirely unreachable.** `committedSearch`/`searchScope` already drove real filtering — nothing in the UI ever set them. Added a search toggle to the header (desktop + compact) with a scope picker (Notes/Profiles/Hashtags) and a field that commits on submit.
- **"Show more" disagreed with what was actually truncated**, in both directions — it used a `> 240 chars` proxy instead of the real 8-line clamp. Replaced with an actual clamped-vs-unclamped height comparison.
- **Zero hover feedback** on the densest, most-clicked element — `isHovered` was declared and never read. Wired `.onHover` on both note layouts, same tint `ProfileResultRow` already uses.
- **Quoted/reposted card was invisible** against its parent: 1.10-1.22:1 fill contrast, 1.17-1.55:1 border — both under the ramp's own 3:1 floor. Swapped the stroke to `Color.borderStrong` (3.16-3.22:1).
- **Notes rows were flush to the pane edges** while Likes/Zaps carried a 16pt inset. Matched it.
- **The Compact toggle read as a 4th nav mode** (same labeled pill as Notes/Likes/Zaps). Switched to `IconFilterButton`, the icon-only language already used for this distinction elsewhere.
- Engagement-bar buttons (reactions/reposts/quotes) get accessibility labels + a real tap target — previously neither.
- Confirmed, no change needed: the audit's 901pt breakpoint is 680pt on current master (post PR #8's dashboard removal) — reasonable as-is.

## Test plan
- [x] `xcodebuild` succeeds for `HavenApp` (macOS) and `HavenApp-iOS`
- [x] Installed + launched on iPhone 17 Pro simulator — clean launch, no crash in the log
- [ ] Human pass: search flow end to end, a genuinely long note vs. one that only *looks* long (many short lines), hover on macOS — no screen-recording permission in this shell to capture it myself

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>