### PR TITLE
Popular feed: collect engagement continuously instead of querying on open

### DIFF
--- a/HavenApp/HavenApp/Services/FeedService.swift
+++ b/HavenApp/HavenApp/Services/FeedService.swift
@@ -384,7 +384,7 @@ class FeedService: ObservableObject {
     private func pollForCuratedGraph() {
         curatedGraphPollTimer?.invalidate()
         curatedGraphPollAttempts = 0
-        guard isGlobalLikeMode, !curatedGraphReady else { return }
+        guard needsCuratedGraph, !curatedGraphReady else { return }
 
         connectionStatus = curatedGraphPendingStatus
         curatedGraphPollTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] timer in
@@ -397,7 +397,7 @@ class FeedService: ObservableObject {
                 // ~2 minutes. If the graph has not appeared by then the relay
                 // could not reach its seed relays, and retrying forever just
                 // burns battery behind a screen that is already honest.
-                guard self.isGlobalLikeMode, self.curatedGraphPollAttempts <= 40 else {
+                guard self.needsCuratedGraph, self.curatedGraphPollAttempts <= 40 else {
                     timer.invalidate()
                     self.curatedGraphPollTimer = nil
                     return
@@ -406,6 +406,14 @@ class FeedService: ObservableObject {
                 if self.curatedGraphReady {
                     timer.invalidate()
                     self.curatedGraphPollTimer = nil
+                    // Popular is computed by the relay, which withholds the
+                    // feed entirely until the same graph exists — re-filtering
+                    // an empty list would leave the user on "Building…"
+                    // forever, so ask for it again now that it can be built.
+                    if self.feedMode == .popular {
+                        self.loadPopularFeed()
+                        return
+                    }
                     self.recomputeFilteredNotes()
                     self.connectionStatus = self.filteredNotes.isEmpty ? "No notes found" : "Live"
                 }
@@ -418,12 +426,20 @@ class FeedService: ObservableObject {
     /// cannot vouch for.
     private func emptyFeedStatus() -> String {
         if !filteredNotes.isEmpty { return "Live" }
-        if isGlobalLikeMode && !curatedGraphReady { return curatedGraphPendingStatus }
+        if needsCuratedGraph && !curatedGraphReady { return curatedGraphPendingStatus }
         return "No notes found"
     }
 
     private var isGlobalLikeMode: Bool {
         feedMode == .global || (feedMode == .media && mediaFeedMode == .global)
+    }
+
+    /// Feeds that cannot be rendered without the trust graph. Global filters
+    /// against it here; Popular is scored against it inside the relay, which
+    /// withholds the feed rather than ranking whatever the largest bot pool
+    /// promoted. Both look identically broken — an empty list — without this.
+    private var needsCuratedGraph: Bool {
+        isGlobalLikeMode || feedMode == .popular
     }
 
 /// In-memory per-account feed snapshots keyed by `activeAccountNpub`
@@ -1024,6 +1040,13 @@ class FeedService: ObservableObject {
     /// Query the local Go DVM for popular notes. The Go backend fetches
     /// engagement data (reactions, reposts, zaps) from seed relays, scores
     /// notes by popularity, and returns the top results.
+    /// "No popular notes found" is wrong while the trust graph is still being
+    /// built: the relay is withholding the feed on purpose, and there is
+    /// something to wait for.
+    private func popularEmptyStatus() -> String {
+        curatedGraphReady ? "No popular notes found" : curatedGraphPendingStatus
+    }
+
     private func loadPopularFeed() {
         guard !isLoadingPopular else { return }
         isLoadingPopular = true
@@ -1091,7 +1114,10 @@ class FeedService: ObservableObject {
                 self.popularNoteScores = scores
                 self.isLoadingPopular = false
                 self.isLoadingFeed = false
-                self.connectionStatus = feedNotes.isEmpty ? "No popular notes found" : "Live"
+                self.connectionStatus = feedNotes.isEmpty ? self.popularEmptyStatus() : "Live"
+                if feedNotes.isEmpty && !self.curatedGraphReady {
+                    self.pollForCuratedGraph()
+                }
                 self.recomputeFilteredNotes()
             }
         }

--- a/haven-go/config.go
+++ b/haven-go/config.go
@@ -83,6 +83,8 @@ type Config struct {
 	FeedSyncWindowDays                   int                 `json:"feed_sync_window_days"`
 	FeedSyncRelays                       []string            `json:"feed_sync_relays"`
 	GoMemLimitMB                         int                 `json:"go_mem_limit_mb"`
+	PopularTallyEnabled                  bool                `json:"popular_tally_enabled"`
+	PopularTallyCachePath                string              `json:"popular_tally_cache_path"`
 }
 
 const relaySoftware = "https://github.com/barrydeen/haven"
@@ -153,6 +155,8 @@ func loadConfig() Config {
 		FeedSyncWindowDays:                   getEnvInt("FEED_SYNC_WINDOW_DAYS", 7),
 		FeedSyncRelays:                       getRelayListFromFile(getEnvString("FEED_SYNC_RELAYS_FILE", "")),
 		GoMemLimitMB:                         getEnvInt("GO_MEM_LIMIT_MB", defaultGoMemLimitMB()),
+		PopularTallyEnabled:                  getEnvBool("POPULAR_TALLY_ENABLED", true),
+		PopularTallyCachePath:                getEnvString("POPULAR_TALLY_CACHE_PATH", "popular_tally.json"),
 	}
 
 	// Relay owner is always whitelisted

--- a/haven-go/cshared.go
+++ b/haven-go/cshared.go
@@ -247,6 +247,7 @@ func StartRelayC(importMode bool) {
 
 			cycle.spawn("subscribeInboxAndChat", func() { subscribeInboxAndChat(cycle.ctx) })
 			cycle.spawn("syncFeed", func() { syncFeed(cycle.ctx) })
+			cycle.spawn("ingestPopularEngagement", func() { ingestPopularEngagement(cycle.ctx) })
 			cycle.spawn("periodicCloudBackups", func() { startPeriodicCloudBackups(cycle.ctx) })
 			cycle.spawn("wot.PeriodicRefresh", func() { wot.PeriodicRefresh(cycle.ctx, config.WotRefreshInterval) })
 		})

--- a/haven-go/dvm.go
+++ b/haven-go/dvm.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"math"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/fiatjaf/eventstore"
 	"github.com/nbd-wtf/go-nostr"
+
+	"github.com/barrydeen/haven/pkg/wot"
 )
 
 // PopularNote holds a note with its computed popularity score.
@@ -37,9 +40,16 @@ var (
 )
 
 const (
-	// A note must have engagement from this many *different* pubkeys (not
-	// counting its own author) before it can appear in the Popular feed.
-	minDistinctReactors = 5
+	// A note must have engagement from this many *different* trusted pubkeys
+	// (not counting its own author) before it can appear in the Popular feed.
+	//
+	// It was 5 while any account's reaction counted. Now that only accounts
+	// inside the owner's web of trust do, the pool is far smaller — measured
+	// on the shipped seed relays, 7.7% of the accounts reacting to anything in
+	// a day were inside the graph — and the bar is harder to clear at the same
+	// number. Five strangers are trivial to manufacture; three people your
+	// follows follow are not.
+	minTrustedReactors = 3
 
 	// Most notes any one author may contribute to a single Popular result set.
 	maxNotesPerAuthor = 3
@@ -261,7 +271,7 @@ func missingIDs(ids []string, found map[string]*nostr.Event) []string {
 // scoreNotes applies the author-exclusion, floor, decay and per-author cap to
 // resolved notes. Split out of computePopularNotes so a test can drive the
 // exact scoring the app sees without a relay pool.
-func scoreNotes(events []*nostr.Event, tally map[string]map[string]float64, now time.Time) []PopularNote {
+func scoreNotes(events []*nostr.Event, tally map[string]map[string]float64, floor int, now time.Time) []PopularNote {
 	var results []PopularNote
 	seen := make(map[string]struct{}, len(events))
 	for _, ev := range events {
@@ -274,7 +284,7 @@ func scoreNotes(events []*nostr.Event, tally map[string]map[string]float64, now 
 		// dropping it can put the note back under the floor — an author plus
 		// four friends is not the same signal as five independent people.
 		rawScore, distinct := scoreExcludingAuthor(tally[ev.ID], ev.PubKey)
-		if distinct < minDistinctReactors {
+		if distinct < floor {
 			continue
 		}
 
@@ -312,6 +322,59 @@ func scoreNotes(events []*nostr.Event, tally map[string]map[string]float64, now 
 	return capPerAuthor(results, maxNotesPerAuthor)
 }
 
+// trustGraph returns the owner's web of trust when it is usable.
+//
+// Why the gate is on the reactors rather than the authors: measured against
+// the shipped seed relays on 2026-09-09, 95 of the top 100 Popular notes were
+// one campaign — 13 accounts posting "In this week's issue", boosted by 6,467
+// accounts of which **two** were inside the owner's graph, while 73 of the 75
+// accounts boosting the five genuine notes were. Gating on the author would
+// have caught half of it at best: 6 of those 13 authors are already inside the
+// graph, because somebody the owner follows follows them. What a manufactured
+// audience cannot fake is being known to the people you actually know.
+func trustGraph(ctx context.Context) (wot.Model, bool) {
+	model := wot.GetInstance()
+	if model == nil || !trustGraphUsable(ctx, model) {
+		return nil, false
+	}
+	return model, true
+}
+
+// filterToTrusted drops engagement from accounts outside the graph, and with
+// it any note left with no trusted engagement at all.
+func filterToTrusted(ctx context.Context, model wot.Model, tally map[string]map[string]float64) map[string]map[string]float64 {
+	trusted := make(map[string]map[string]float64, len(tally))
+	for target, reactors := range tally {
+		kept := make(map[string]float64, len(reactors))
+		for pk, w := range reactors {
+			if model.Has(ctx, pk) {
+				kept[pk] = w
+			}
+		}
+		if len(kept) > 0 {
+			trusted[target] = kept
+		}
+	}
+	return trusted
+}
+
+// trustGraphUsable reports whether the model can actually answer questions.
+//
+// Has() returns false for everything both when a pubkey is untrusted and when
+// the graph has not been built yet, so a size check is needed to tell a cold
+// start from a world of strangers. A model that answers true for a pubkey
+// nobody has ever seen is one with the graph disabled (WOT_DEPTH=0), which is
+// a deliberate configuration: the gate is then a no-op rather than a wall.
+func trustGraphUsable(ctx context.Context, model wot.Model) bool {
+	if sized, ok := model.(interface{ Size() int }); ok && sized.Size() > 0 {
+		return true
+	}
+	var nobody [32]byte
+	nobody[0] = 0x0f
+	nobody[31] = 0xf0
+	return model.Has(ctx, hex.EncodeToString(nobody[:]))
+}
+
 // computePopularNotes answers the Popular feed.
 //
 // It reads the rolling tally the always-on subscription has been filling
@@ -331,6 +394,17 @@ func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
 	}
 	popularCacheMu.Unlock()
 
+	// Fails closed, and before anything expensive. An unusable graph means the
+	// only feed we could build is the open firehose, which is how the spam got
+	// in — the Global feed makes the same call, and its comment records that
+	// firehose as measuring two thirds spam. The relay writes a graph shortly
+	// after first launch.
+	model, gated := trustGraph(ctx)
+	if !gated {
+		log.Println("popular: trust graph not ready, withholding the feed")
+		return []PopularNote{}, nil
+	}
+
 	tally := popularTally.snapshot(now)
 	coverage := popularTally.coverage(now)
 
@@ -347,9 +421,19 @@ func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
 		return []PopularNote{}, nil
 	}
 
-	ranked := rankTargets(tally, minDistinctReactors)
-	log.Printf("popular: %d candidate notes, %d eligible at %d distinct reactors (coverage %.0f%%, %s)",
-		len(tally), len(ranked), minDistinctReactors, coverage*100,
+	// Only engagement from inside the owner's web of trust counts. Without
+	// this the feed is whatever the largest bot pool decided to promote.
+	raw := len(tally)
+	tally = filterToTrusted(ctx, model, tally)
+	floor := minTrustedReactors
+
+	if len(tally) == 0 {
+		return []PopularNote{}, nil
+	}
+
+	ranked := rankTargets(tally, floor)
+	log.Printf("popular: %d candidate notes (%d before the trust gate), %d eligible at %d trusted reactors (coverage %.0f%%, %s)",
+		len(tally), raw, len(ranked), floor, coverage*100,
 		map[bool]string{true: "local", false: "backfilled"}[local])
 	if len(ranked) == 0 {
 		return []PopularNote{}, nil
@@ -363,7 +447,7 @@ func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
 		topIDs[i] = r.id
 	}
 
-	results := scoreNotes(resolveNoteBodies(ctx, topIDs), tally, now)
+	results := scoreNotes(resolveNoteBodies(ctx, topIDs), tally, floor, now)
 
 	ttl := popularCacheTTL
 	if local {

--- a/haven-go/dvm.go
+++ b/haven-go/dvm.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fiatjaf/eventstore"
 	"github.com/nbd-wtf/go-nostr"
 )
 
@@ -24,10 +25,15 @@ type PopularNote struct {
 }
 
 var (
-	popularCache     []PopularNote
-	popularCacheTime time.Time
-	popularCacheMu   sync.Mutex
-	popularCacheTTL  = 5 * time.Minute
+	popularCache       []PopularNote
+	popularCacheExpiry time.Time
+	popularCacheMu     sync.Mutex
+
+	// A result that cost a network round trip is held longer than one read
+	// out of the local tally: the fetch is what we are trying to avoid, and
+	// the local read is cheap enough to redo for fresher ranking.
+	popularCacheTTL      = 5 * time.Minute
+	popularLocalCacheTTL = 60 * time.Second
 )
 
 const (
@@ -67,15 +73,8 @@ func addEngagement(tally map[string]map[string]float64, ev *nostr.Event) {
 	if ev == nil {
 		return
 	}
-	var weight float64
-	switch ev.Kind {
-	case 7:
-		weight = 1.0 // reaction
-	case 6:
-		weight = 2.0 // repost
-	case 9735:
-		weight = 3.0 // zap
-	default:
+	weight := engagementWeight(ev.Kind)
+	if weight == 0 {
 		return
 	}
 
@@ -160,100 +159,116 @@ func capPerAuthor(notes []PopularNote, limit int) []PopularNote {
 	return kept
 }
 
-// computePopularNotes queries seed relays for engagement data, scores notes
-// by popularity, fetches the top note contents, and returns them ranked.
-func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
-	// Check cache first
-	popularCacheMu.Lock()
-	if time.Since(popularCacheTime) < popularCacheTTL && len(popularCache) > 0 {
-		cached := make([]PopularNote, len(popularCache))
-		copy(cached, popularCache)
-		popularCacheMu.Unlock()
-		return cached, nil
-	}
-	popularCacheMu.Unlock()
-
+// fetchEngagementInto pulls the last 24h of engagement events from the seed
+// relays and folds them into an existing tally. This is the original
+// snapshot path, kept as the backfill for a device whose passive tally has not
+// been running long enough to answer on its own — a phone the OS suspends
+// between glances. Folding into the same map rather than replacing it means a
+// backfilled read is still strictly better informed than today's: it has the
+// network's snapshot *plus* whatever this device watched arrive live.
+// A variable, not a plain function, so a test can observe whether the read
+// path reached for the network at all — the assertion "Popular was answered
+// locally" is otherwise indistinguishable from "the fetch failed and its error
+// was swallowed", which is exactly how the first version of that test passed
+// against code that always fetched.
+var fetchEngagementInto = func(ctx context.Context, tally map[string]map[string]float64) error {
 	if pool == nil {
-		return nil, fmt.Errorf("relay pool not initialized")
+		return fmt.Errorf("relay pool not initialized")
 	}
-
 	relays := config.ImportSeedRelays
 	if len(relays) == 0 {
-		return nil, fmt.Errorf("no seed relays configured")
+		return fmt.Errorf("no seed relays configured")
 	}
 
-	// Phase 1: Fetch engagement events from last 24h
 	since := nostr.Timestamp(time.Now().Add(-24 * time.Hour).Unix())
-
 	engagementFilter := nostr.Filter{
 		Kinds: []int{7, 6, 9735},
 		Since: &since,
 		Limit: 5000,
 	}
 
-	// targetNoteID -> reactorPubkey -> that reactor's best single weight.
-	// Scoring per *reactor* rather than per engagement event is the anti-spam
-	// core: an earlier version summed every event, so one account liking the
-	// same note five hundred times added five hundred points. A reactor now
-	// contributes once, at the strongest thing they did (zap beats repost
-	// beats like), so gaming the feed costs distinct identities, not clicks.
-	tally := make(map[string]map[string]float64)
-	seenIDs := make(map[string]struct{}) // dedup engagement events
-
 	fetchCtx, fetchCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer fetchCancel()
 
-	events := pool.FetchMany(fetchCtx, relays, engagementFilter)
-	for ev := range events {
+	seenIDs := make(map[string]struct{})
+	for ev := range pool.FetchMany(fetchCtx, relays, engagementFilter) {
 		if _, seen := seenIDs[ev.ID]; seen {
 			continue
 		}
 		seenIDs[ev.ID] = struct{}{}
-
 		addEngagement(tally, ev.Event)
 	}
+	return nil
+}
 
-	if len(tally) == 0 {
-		return []PopularNote{}, nil
-	}
+// resolveNoteBodies finds the note behind each winning id, local stores first.
+// The tally only ever holds target ids; on a device that has been running, the
+// notes people are reacting to are usually already in the feed cache, so the
+// common case costs no network at all. Only the ids nothing local knows about
+// are fetched, and there are at most a hundred of them.
+func resolveNoteBodies(ctx context.Context, ids []string) []*nostr.Event {
+	found := make(map[string]*nostr.Event, len(ids))
 
-	// Rank by score, take top 100. A note needs engagement from at least
-	// minDistinctReactors different people to be eligible at all — one
-	// account boosting its own note can no longer reach the feed however
-	// hard it tries.
-	ranked := rankTargets(tally, minDistinctReactors)
-	log.Printf("popular: %d candidate notes, %d eligible at %d distinct reactors",
-		len(tally), len(ranked), minDistinctReactors)
-	if len(ranked) == 0 {
-		return []PopularNote{}, nil
-	}
-	if len(ranked) > 100 {
-		ranked = ranked[:100]
-	}
-
-	topIDs := make([]string, len(ranked))
-	for i, r := range ranked {
-		topIDs[i] = r.id
-	}
-
-	// Phase 2: Fetch actual note content for top IDs
-	noteFilter := nostr.Filter{
-		Kinds: []int{1, 30023},
-		IDs:   topIDs,
-	}
-
-	noteCtx, noteCancel := context.WithTimeout(ctx, 15*time.Second)
-	defer noteCancel()
-
-	var results []PopularNote
-	seenNotes := make(map[string]struct{})
-
-	noteEvents := pool.FetchMany(noteCtx, relays, noteFilter)
-	for ev := range noteEvents {
-		if _, seen := seenNotes[ev.ID]; seen {
+	for _, db := range []DBBackend{feedDB, outboxDB, inboxDB, privateDB} {
+		if db == nil || len(found) == len(ids) {
 			continue
 		}
-		seenNotes[ev.ID] = struct{}{}
+		missing := missingIDs(ids, found)
+		if len(missing) == 0 {
+			break
+		}
+		wdb := eventstore.RelayWrapper{Store: db}
+		evs, err := wdb.QuerySync(ctx, nostr.Filter{Kinds: []int{1, 30023}, IDs: missing})
+		if err != nil {
+			continue
+		}
+		for _, ev := range evs {
+			found[ev.ID] = ev
+		}
+	}
+
+	if missing := missingIDs(ids, found); len(missing) > 0 && pool != nil {
+		relays := config.ImportSeedRelays
+		if len(relays) > 0 {
+			noteCtx, noteCancel := context.WithTimeout(ctx, 15*time.Second)
+			defer noteCancel()
+			for ev := range pool.FetchMany(noteCtx, relays, nostr.Filter{Kinds: []int{1, 30023}, IDs: missing}) {
+				if _, have := found[ev.ID]; !have {
+					found[ev.ID] = ev.Event
+				}
+			}
+		}
+	}
+
+	out := make([]*nostr.Event, 0, len(found))
+	for _, ev := range found {
+		out = append(out, ev)
+	}
+	return out
+}
+
+// missingIDs returns the ids not yet resolved, preserving order.
+func missingIDs(ids []string, found map[string]*nostr.Event) []string {
+	missing := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := found[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing
+}
+
+// scoreNotes applies the author-exclusion, floor, decay and per-author cap to
+// resolved notes. Split out of computePopularNotes so a test can drive the
+// exact scoring the app sees without a relay pool.
+func scoreNotes(events []*nostr.Event, tally map[string]map[string]float64, now time.Time) []PopularNote {
+	var results []PopularNote
+	seen := make(map[string]struct{}, len(events))
+	for _, ev := range events {
+		if _, dup := seen[ev.ID]; dup {
+			continue
+		}
+		seen[ev.ID] = struct{}{}
 
 		// The author's own engagement with their own note does not count, and
 		// dropping it can put the note back under the floor — an author plus
@@ -264,7 +279,7 @@ func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
 		}
 
 		// Time decay: notes older than 12h start losing score
-		ageHours := time.Since(ev.CreatedAt.Time()).Hours()
+		ageHours := now.Sub(ev.CreatedAt.Time()).Hours()
 		decay := math.Max(0.2, 1.0-math.Max(0, ageHours-12)*0.05)
 
 		tags := make([][]string, len(ev.Tags))
@@ -283,22 +298,81 @@ func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
 		})
 	}
 
-	// Sort by final score descending
 	sort.Slice(results, func(i, j int) bool {
-		return results[i].Score > results[j].Score
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].ID < results[j].ID
 	})
 
 	// No single author may own the feed. Even a legitimately viral account
 	// posting ten times in a day should not push everyone else off the
 	// screen, and it denies a spammer who does clear the floor the ability
 	// to fill it. Applied after sorting so each author keeps their best.
-	results = capPerAuthor(results, maxNotesPerAuthor)
+	return capPerAuthor(results, maxNotesPerAuthor)
+}
 
-	// Update cache
+// computePopularNotes answers the Popular feed.
+//
+// It reads the rolling tally the always-on subscription has been filling
+// (popular_tally.go) and only reaches for the network when that tally has not
+// been running long enough to be trusted on its own. The scoring below is the
+// same code the old snapshot-only path used; what changed is where the
+// engagement data comes from.
+func computePopularNotes(ctx context.Context) ([]PopularNote, error) {
+	now := time.Now()
+
+	popularCacheMu.Lock()
+	if now.Before(popularCacheExpiry) && len(popularCache) > 0 {
+		cached := make([]PopularNote, len(popularCache))
+		copy(cached, popularCache)
+		popularCacheMu.Unlock()
+		return cached, nil
+	}
+	popularCacheMu.Unlock()
+
+	tally := popularTally.snapshot(now)
+	coverage := popularTally.coverage(now)
+
+	// Below the coverage floor the tally is a partial view — a phone that was
+	// awake for ten minutes knows about ten minutes of engagement. Backfill.
+	local := coverage >= popularTallyMinCoverage
+	if !local {
+		if err := fetchEngagementInto(ctx, tally); err != nil && len(tally) == 0 {
+			return nil, err
+		}
+	}
+
+	if len(tally) == 0 {
+		return []PopularNote{}, nil
+	}
+
+	ranked := rankTargets(tally, minDistinctReactors)
+	log.Printf("popular: %d candidate notes, %d eligible at %d distinct reactors (coverage %.0f%%, %s)",
+		len(tally), len(ranked), minDistinctReactors, coverage*100,
+		map[bool]string{true: "local", false: "backfilled"}[local])
+	if len(ranked) == 0 {
+		return []PopularNote{}, nil
+	}
+	if len(ranked) > 100 {
+		ranked = ranked[:100]
+	}
+
+	topIDs := make([]string, len(ranked))
+	for i, r := range ranked {
+		topIDs[i] = r.id
+	}
+
+	results := scoreNotes(resolveNoteBodies(ctx, topIDs), tally, now)
+
+	ttl := popularCacheTTL
+	if local {
+		ttl = popularLocalCacheTTL
+	}
 	popularCacheMu.Lock()
 	popularCache = make([]PopularNote, len(results))
 	copy(popularCache, results)
-	popularCacheTime = time.Now()
+	popularCacheExpiry = now.Add(ttl)
 	popularCacheMu.Unlock()
 
 	return results, nil

--- a/haven-go/dvm_test.go
+++ b/haven-go/dvm_test.go
@@ -128,15 +128,15 @@ func TestScoreExcludingAuthor(t *testing.T) {
 	}
 }
 
-// An author plus four friends is not five independent people.
+// An author plus two friends is not three independent people.
 func TestScoreExcludingAuthorCanDropBelowFloor(t *testing.T) {
-	reactors := map[string]float64{"author": 1, "a": 1, "b": 1, "c": 1, "d": 1}
-	if len(reactors) < minDistinctReactors {
+	reactors := map[string]float64{"author": 1, "a": 1, "b": 1}
+	if len(reactors) < minTrustedReactors {
 		t.Fatalf("test setup: want a note that passes the raw floor")
 	}
 	_, distinct := scoreExcludingAuthor(reactors, "author")
-	if distinct >= minDistinctReactors {
-		t.Errorf("distinct = %d, want below the floor of %d", distinct, minDistinctReactors)
+	if distinct >= minTrustedReactors {
+		t.Errorf("distinct = %d, want below the floor of %d", distinct, minTrustedReactors)
 	}
 }
 

--- a/haven-go/main.go
+++ b/haven-go/main.go
@@ -121,6 +121,7 @@ func main() {
 
 		runsafe.Go("subscribeInboxAndChat", func() { subscribeInboxAndChat(mainCtx) })
 		runsafe.Go("syncFeed", func() { syncFeed(mainCtx) })
+		runsafe.Go("ingestPopularEngagement", func() { ingestPopularEngagement(mainCtx) })
 		runsafe.Go("periodicCloudBackups", func() { startPeriodicCloudBackups(mainCtx) })
 		runsafe.Go("wot.PeriodicRefresh", func() { wot.PeriodicRefresh(mainCtx, config.WotRefreshInterval) })
 	})

--- a/haven-go/negsync_test.go
+++ b/haven-go/negsync_test.go
@@ -18,11 +18,24 @@ import (
 	"github.com/barrydeen/haven/pkg/wot"
 )
 
-// stubWot satisfies wot.Model with a fixed answer. A single concrete type is
-// required because wot's atomic.Value rejects inconsistently-typed stores.
-type stubWot struct{ allow bool }
+// stubWot satisfies wot.Model. A single concrete type is required because
+// wot's atomic.Value rejects inconsistently-typed stores — every test in this
+// package that installs a graph must use this one, which is why it carries
+// both shapes: `allow` answers true for everyone (the WOT_DEPTH=0
+// configuration), `members` is an actual graph.
+type stubWot struct {
+	allow   bool
+	members map[string]bool
+}
 
-func (s stubWot) Has(context.Context, string) bool { return s.allow }
+func (s stubWot) Has(_ context.Context, pubkey string) bool {
+	return s.allow || s.members[pubkey]
+}
+
+// Size lets a caller tell an empty graph from an untrusted pubkey; both make
+// Has return false. An allow-everyone stub reports 0 and is recognised by its
+// answers instead.
+func (s stubWot) Size() int { return len(s.members) }
 
 func hexid(c byte) string { return strings.Repeat(string(c), 64) }
 

--- a/haven-go/pkg/wot/simple_in_memory.go
+++ b/haven-go/pkg/wot/simple_in_memory.go
@@ -66,6 +66,20 @@ func (wt *SimpleInMemory) WithFallbackSeeds(pubkeys []string) *SimpleInMemory {
 	return wt
 }
 
+// Size reports how many pubkeys the graph currently holds.
+//
+// Has() alone cannot tell "this pubkey is untrusted" apart from "the graph has
+// not been built yet" — both answer false. Anything that fails closed on an
+// untrusted key therefore needs to know whether there is a graph at all, or a
+// cold start looks exactly like a world full of strangers.
+func (wt *SimpleInMemory) Size() int {
+	m := wt.pubkeys.Load()
+	if m == nil {
+		return 0
+	}
+	return len(*m)
+}
+
 func (wt *SimpleInMemory) Has(_ context.Context, pubKey string) bool {
 	if wt.WotDepth == 0 {
 		return true

--- a/haven-go/popular_tally.go
+++ b/haven-go/popular_tally.go
@@ -1,0 +1,618 @@
+package main
+
+// Passive popularity tally.
+//
+// The Popular feed used to exist only as a pull: every time the tab was opened
+// past its cache, computePopularNotes fired a fresh REQ at the seed relays for
+// the last 24h of kinds 7/6/9735 and scored whatever came back. That has a
+// ceiling nothing in our code can raise — relays cap a REQ's response, and the
+// ones we ship with return roughly the last half hour however large a Limit we
+// ask for. The 24h window was aspirational, not real.
+//
+// This file makes the always-on relay do the collecting instead: a live
+// subscription feeds a rolling 24h tally, so Popular reads state we have been
+// accumulating rather than a snapshot a relay was willing to hand over. On a
+// Mac left running that converges to no outbound query at all; on a phone,
+// where the OS suspends the process, the tally only advances while the app is
+// foregrounded, so dvm.go still backfills from the network when coverage is
+// thin (see popularTallyMinCoverage).
+//
+// Only the collection changes. The scoring rules stay in dvm.go and are used
+// unchanged — TestTallyRankingMatchesBatch pins that.
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+const (
+	// How far back the tally scores. Matches the window dvm.go's fetch asks
+	// for, so the two paths remain comparable.
+	popularWindow = 24 * time.Hour
+
+	// A bucket is one clock hour of engagement. Eviction is then dropping a
+	// map, not scanning one, and the window edge is exact.
+	popularBucketSpan = time.Hour
+
+	// Ceiling on targets held across the whole window, not per bucket: a
+	// per-bucket cap bounds nothing useful, because 24 buckets each under it
+	// still add up to 24 times the number you thought you had allowed.
+	//
+	// Measured cost of the real thing: a full day off the shipped seed relays
+	// is ~12.3k engagements over ~3.6k targets, which the tally holds in 4 MB
+	// (10x that: 40 MB). 25k targets is roughly 7x the observed load and about
+	// 29 MB — headroom for a much busier relay set while staying an order of
+	// magnitude under the long-form bodies that made this app a jetsam target.
+	popularMaxTargets = 25_000
+
+	// Fraction of the last 24h the tally must cover before Popular is answered
+	// from local state alone. Below it, dvm.go adds a network fetch on top of
+	// whatever the tally holds.
+	popularTallyMinCoverage = 0.5
+
+	// Targets an hour bucket must hold before that hour counts as covered by
+	// the data rather than by uptime. Small enough that a quiet hour still
+	// counts, large enough that one stray replayed event does not.
+	popularBucketMinTargets = 5
+
+	// Longest gap credited as "connected" between two liveness marks. A gap
+	// larger than this is downtime, not coverage — without the cap a process
+	// that slept for six hours would wake up and claim it had been watching.
+	popularCoverageMaxStep = 90 * time.Second
+
+	// How often the ingest loop marks itself alive while idle. Well under the
+	// cap above, so a healthy but quiet subscription still accrues coverage.
+	popularCoverageMarkEvery = 30 * time.Second
+
+	// Events dated further ahead than this are ignored. created_at is
+	// attacker-controlled: without the guard a note stamped a year out would
+	// sit in a bucket the window never evicts.
+	popularMaxClockSkew = 10 * time.Minute
+)
+
+// engagementTally is a rolling 24h record of who engaged with what.
+//
+// Shape inside a bucket is deliberately identical to the map dvm.go's batch
+// path builds (target -> reactor -> that reactor's strongest weight) so the
+// existing scoring functions consume a merged snapshot with no adaptation.
+//
+// Reactor pubkeys are stored as full hex, not truncated. An earlier draft
+// keyed them by the first 8 bytes to save memory; that silently weakens
+// scoreExcludingAuthor, which excludes a note's own author by comparing that
+// key — a truncation collision would drop a real reactor's weight or, worse,
+// let an author's own engagement pass as somebody else's. Interning the
+// strings gets most of the memory back without touching the comparison.
+type engagementTally struct {
+	mu      sync.Mutex
+	buckets map[int64]map[string]map[string]float64 // bucket index -> target -> reactor -> weight
+	covered map[int64]float64                       // bucket index -> seconds connected
+	intern  map[string]string                       // one backing string per distinct pubkey
+	lastMk  time.Time                               // last liveness mark
+	total   int                                     // target entries across all buckets
+}
+
+var popularTally = newEngagementTally()
+
+func newEngagementTally() *engagementTally {
+	return &engagementTally{
+		buckets: make(map[int64]map[string]map[string]float64),
+		covered: make(map[int64]float64),
+		intern:  make(map[string]string),
+	}
+}
+
+// bucketIndex is the clock-hour an instant falls in.
+func bucketIndex(t time.Time) int64 { return t.Unix() / int64(popularBucketSpan/time.Second) }
+
+// intern returns a shared instance of s. Caller holds the lock.
+func (t *engagementTally) internLocked(s string) string {
+	if existing, ok := t.intern[s]; ok {
+		return existing
+	}
+	t.intern[s] = s
+	return s
+}
+
+// add records one engagement event, or ignores it. Mirrors addEngagement's
+// rules (same kinds, same weights, strongest-wins per reactor) but files the
+// entry in the bucket its created_at falls in.
+func (t *engagementTally) add(ev *nostr.Event, now time.Time) {
+	if ev == nil {
+		return
+	}
+	weight := engagementWeight(ev.Kind)
+	if weight == 0 {
+		return
+	}
+	target := reactionTargetID(ev.Tags)
+	if target == "" {
+		return
+	}
+	at := ev.CreatedAt.Time()
+	if at.After(now.Add(popularMaxClockSkew)) || at.Before(now.Add(-popularWindow)) {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	idx := bucketIndex(at)
+	bucket := t.buckets[idx]
+	if bucket == nil {
+		bucket = make(map[string]map[string]float64)
+		t.buckets[idx] = bucket
+	}
+	reactors := bucket[target]
+	if reactors == nil {
+		if t.total >= popularMaxTargets && !t.dropSingletonsLocked() {
+			return // nothing left to shed but real candidates; do not grow
+		}
+		reactors = make(map[string]float64, 1)
+		bucket[t.internLocked(target)] = reactors
+		t.total++
+	}
+	if pk := t.internLocked(ev.PubKey); weight > reactors[pk] {
+		reactors[pk] = weight
+	}
+}
+
+// dropSingletonsLocked frees room by discarding targets only one person
+// engaged with, oldest hour first. Those are ~78% of the map and cannot reach
+// minDistinctReactors before their hour rolls out of the window anyway.
+// Reports whether it freed anything.
+func (t *engagementTally) dropSingletonsLocked() bool {
+	indexes := make([]int64, 0, len(t.buckets))
+	for idx := range t.buckets {
+		indexes = append(indexes, idx)
+	}
+	sort.Slice(indexes, func(i, j int) bool { return indexes[i] < indexes[j] })
+
+	freed := false
+	for _, idx := range indexes {
+		bucket := t.buckets[idx]
+		for target, reactors := range bucket {
+			if len(reactors) <= 1 {
+				delete(bucket, target)
+				t.total--
+				freed = true
+			}
+		}
+		// One hour's singletons is usually plenty; stopping early keeps the
+		// newest hours intact, which is where the next winners come from.
+		if freed {
+			break
+		}
+	}
+	return freed
+}
+
+// markAlive credits the time since the previous mark as connected, up to
+// popularCoverageMaxStep. The ingest loop calls it on every event and on a
+// ticker, so coverage measures socket uptime rather than traffic volume — a
+// quiet hour with a healthy subscription still counts as watched.
+func (t *engagementTally) markAlive(now time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	last := t.lastMk
+	t.lastMk = now
+	if last.IsZero() {
+		return
+	}
+	step := now.Sub(last)
+	if step <= 0 {
+		return
+	}
+	if step > popularCoverageMaxStep {
+		step = popularCoverageMaxStep
+	}
+	idx := bucketIndex(now)
+	if seconds := t.covered[idx] + step.Seconds(); seconds < popularBucketSpan.Seconds() {
+		t.covered[idx] = seconds
+	} else {
+		t.covered[idx] = popularBucketSpan.Seconds()
+	}
+	t.pruneLocked(now)
+}
+
+// pruneLocked drops buckets that have fallen out of the window.
+func (t *engagementTally) pruneLocked(now time.Time) {
+	oldest := bucketIndex(now.Add(-popularWindow))
+	for idx, bucket := range t.buckets {
+		if idx < oldest {
+			t.total -= len(bucket)
+			delete(t.buckets, idx)
+		}
+	}
+	for idx := range t.covered {
+		if idx < oldest {
+			delete(t.covered, idx)
+		}
+	}
+	// Interned strings for evicted buckets are unreachable but still held by
+	// the intern table; rebuild it from what survives rather than letting it
+	// grow for the process lifetime.
+	if len(t.intern) > 4*popularMaxTargets {
+		t.rebuildInternLocked()
+	}
+}
+
+func (t *engagementTally) rebuildInternLocked() {
+	fresh := make(map[string]string, len(t.intern)/2)
+	for _, bucket := range t.buckets {
+		for target, reactors := range bucket {
+			fresh[target] = target
+			for pk := range reactors {
+				fresh[pk] = pk
+			}
+		}
+	}
+	t.intern = fresh
+}
+
+// snapshot merges the live buckets into one target -> reactor -> weight map of
+// the shape dvm.go scores. A reactor who engaged in several hours contributes
+// once, at their strongest weight — the same rule addEngagement applies within
+// a single batch, so splitting the window into buckets cannot change a score.
+func (t *engagementTally) snapshot(now time.Time) map[string]map[string]float64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pruneLocked(now)
+
+	merged := make(map[string]map[string]float64)
+	for _, bucket := range t.buckets {
+		for target, reactors := range bucket {
+			into := merged[target]
+			if into == nil {
+				into = make(map[string]float64, len(reactors))
+				merged[target] = into
+			}
+			for pk, w := range reactors {
+				if w > into[pk] {
+					into[pk] = w
+				}
+			}
+		}
+	}
+	return merged
+}
+
+// coverage is how much of the last 24h the tally can actually speak for,
+// which is the larger of two measures:
+//
+//   - uptime: how long the ingest loop held a subscription;
+//   - data: how many of the 24 hour buckets hold real engagement.
+//
+// The second exists because relays replay history when a subscription opens
+// with a 24h `since` — a cold start on a phone collects most of a day inside
+// the first minute. Measured live: 90 seconds of ingestion filled all 24
+// buckets with 12k engagements. Scoring uptime alone would have declared that
+// tally 0.1% covered and sent it to the network for data it was already
+// holding, which is the very query this work exists to remove.
+func (t *engagementTally) coverage(now time.Time) float64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pruneLocked(now)
+
+	var seconds float64
+	for _, s := range t.covered {
+		seconds += s
+	}
+	uptime := seconds / popularWindow.Seconds()
+
+	populated := 0
+	for _, bucket := range t.buckets {
+		if len(bucket) >= popularBucketMinTargets {
+			populated++
+		}
+	}
+	data := float64(populated) / float64(popularWindow/popularBucketSpan)
+	if data > 1 {
+		data = 1
+	}
+
+	if data > uptime {
+		return data
+	}
+	return uptime
+}
+
+// stats reports what the tally is holding, for logging.
+func (t *engagementTally) stats(now time.Time) (targets int, buckets int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pruneLocked(now)
+	seen := make(map[string]struct{})
+	for _, bucket := range t.buckets {
+		for target := range bucket {
+			seen[target] = struct{}{}
+		}
+	}
+	return len(seen), len(t.buckets)
+}
+
+// engagementWeight is the score one reactor's strongest action is worth. Single
+// definition, shared by the batch path (addEngagement) and the tally, so the
+// two cannot drift apart.
+func engagementWeight(kind int) float64 {
+	switch kind {
+	case 7:
+		return 1.0 // reaction
+	case 6:
+		return 2.0 // repost
+	case 9735:
+		return 3.0 // zap
+	default:
+		return 0
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+// tallySnapshotFile is the on-disk form. Buckets are keyed by index so a
+// reload lands in exactly the hours the events belong to, and anything outside
+// the window is discarded on load — which is also what keeps the file from
+// growing: it is rewritten, never appended.
+type tallySnapshotFile struct {
+	SavedAt int64                                   `json:"saved_at"`
+	Buckets map[int64]map[string]map[string]float64 `json:"buckets"`
+	Covered map[int64]float64                       `json:"covered"`
+}
+
+// save writes the tally so a relaunch does not start from nothing. Targets
+// only one person ever engaged with are left out: they are most of the map and
+// none of the answer.
+//
+// "Only one person" is counted across the whole window, not per bucket. A
+// first draft filtered each bucket on its own and quietly discarded exactly
+// the notes Popular exists for — a note with six reactors spread over six
+// hours has one reactor in each hour, so every bucket looked like a singleton
+// and the whole note vanished from the file. The round-trip ranking test
+// caught it.
+func (t *engagementTally) save(path string, now time.Time) error {
+	t.mu.Lock()
+	t.pruneLocked(now)
+
+	windowReactors := make(map[string]map[string]struct{})
+	for _, bucket := range t.buckets {
+		for target, reactors := range bucket {
+			seen := windowReactors[target]
+			if seen == nil {
+				seen = make(map[string]struct{}, len(reactors))
+				windowReactors[target] = seen
+			}
+			for pk := range reactors {
+				seen[pk] = struct{}{}
+			}
+		}
+	}
+
+	out := tallySnapshotFile{
+		SavedAt: now.Unix(),
+		Buckets: make(map[int64]map[string]map[string]float64, len(t.buckets)),
+		Covered: make(map[int64]float64, len(t.covered)),
+	}
+	for idx, bucket := range t.buckets {
+		kept := make(map[string]map[string]float64)
+		for target, reactors := range bucket {
+			if len(windowReactors[target]) < 2 {
+				continue
+			}
+			copied := make(map[string]float64, len(reactors))
+			for pk, w := range reactors {
+				copied[pk] = w
+			}
+			kept[target] = copied
+		}
+		if len(kept) > 0 {
+			out.Buckets[idx] = kept
+		}
+	}
+	for idx, s := range t.covered {
+		out.Covered[idx] = s
+	}
+	t.mu.Unlock()
+
+	data, err := json.Marshal(out)
+	if err != nil {
+		return err
+	}
+	// Write-then-rename: a snapshot truncated by a kill would otherwise be
+	// unparseable on the next launch, and the tally would silently start empty.
+	tmp := path + ".tmp"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// load restores a saved tally, dropping anything now outside the window.
+// A missing or unreadable file is not an error: the tally simply starts empty
+// and the read path backfills from the network until coverage recovers.
+func (t *engagementTally) load(path string, now time.Time) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var in tallySnapshotFile
+	if err := json.Unmarshal(data, &in); err != nil {
+		log.Printf("popular: ignoring unreadable tally snapshot: %v", err)
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	oldest := bucketIndex(now.Add(-popularWindow))
+	for idx, bucket := range in.Buckets {
+		if idx < oldest {
+			continue
+		}
+		into := t.buckets[idx]
+		if into == nil {
+			into = make(map[string]map[string]float64, len(bucket))
+			t.buckets[idx] = into
+		}
+		for target, reactors := range bucket {
+			key := t.internLocked(target)
+			dst := into[key]
+			if dst == nil {
+				dst = make(map[string]float64, len(reactors))
+				into[key] = dst
+				t.total++
+			}
+			for pk, w := range reactors {
+				if pk := t.internLocked(pk); w > dst[pk] {
+					dst[pk] = w
+				}
+			}
+		}
+	}
+	for idx, s := range in.Covered {
+		if idx < oldest {
+			continue
+		}
+		if s > t.covered[idx] {
+			t.covered[idx] = s
+		}
+	}
+}
+
+// popularTallyPath is where the snapshot lives, beside the other caches.
+func popularTallyPath() string {
+	return config.PopularTallyCachePath
+}
+
+// ---------------------------------------------------------------------------
+// Ingest
+// ---------------------------------------------------------------------------
+
+// ingestPopularEngagement keeps a live subscription to the seed relays for
+// engagement kinds and feeds everything it sees to the tally.
+//
+// Loop shape is the inbox subscription's (import.go): SubscribeMany's channel
+// closes on context cancel or when every relay sends CLOSED, so a close is
+// treated as reconnect-with-capped-backoff rather than as terminal.
+func ingestPopularEngagement(ctx context.Context) {
+	if !config.PopularTallyEnabled {
+		log.Println("📊 popular tally disabled")
+		return
+	}
+	if pool == nil {
+		return
+	}
+	relays := config.ImportSeedRelays
+	if len(relays) == 0 {
+		log.Println("📊 popular tally: no seed relays configured")
+		return
+	}
+
+	popularTally.load(popularTallyPath(), time.Now())
+	if targets, buckets := popularTally.stats(time.Now()); targets > 0 {
+		log.Printf("📊 popular tally restored: %d targets across %d hours", targets, buckets)
+	}
+
+	go persistPopularTally(ctx)
+
+	log.Println("📊 subscribing to engagement (kinds 7/6/9735) on", len(relays), "relays")
+	backoff := time.Second
+	var watermark int64
+	for ctx.Err() == nil {
+		since := ingestSince(watermark, time.Now())
+		filter := nostr.Filter{Kinds: []int{7, 6, 9735}, Since: &since}
+
+		sawEvent := false
+		mark := time.NewTicker(popularCoverageMarkEvery)
+		done := make(chan struct{})
+		go func() {
+			// Liveness marks while the subscription is quiet. Without this a
+			// healthy but idle socket would accrue no coverage and Popular
+			// would keep paying for a network fetch it does not need.
+			for {
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				case now := <-mark.C:
+					popularTally.markAlive(now)
+				}
+			}
+		}()
+
+		popularTally.markAlive(time.Now())
+		for ev := range pool.SubscribeMany(ctx, relays, filter) {
+			sawEvent = true
+			now := time.Now()
+			popularTally.markAlive(now)
+			popularTally.add(ev.Event, now)
+			if at := int64(ev.CreatedAt); at > watermark && at <= now.Add(popularMaxClockSkew).Unix() {
+				watermark = at
+			}
+		}
+		mark.Stop()
+		close(done)
+
+		if ctx.Err() != nil {
+			break
+		}
+		if sawEvent {
+			backoff = time.Second
+		}
+		log.Println("📊 popular tally subscription closed, reconnecting in", backoff)
+		select {
+		case <-ctx.Done():
+		case <-time.After(backoff):
+		}
+		if backoff < 60*time.Second {
+			backoff *= 2
+		}
+	}
+	// Best effort on the way out; the periodic save covers a hard kill.
+	_ = popularTally.save(popularTallyPath(), time.Now())
+}
+
+// ingestSince is where a subscription resumes from.
+//
+// The first pass asks for the whole window, and the relays' replay of it is
+// what makes a cold start useful immediately (measured: 24 buckets filled in
+// 90 seconds). Every reconnect after that resumes from the newest event
+// already seen — without the watermark a flaky connection would re-download
+// the same day of history on every retry, which on cellular is the sort of
+// thing that gets an app uninstalled.
+func ingestSince(watermark int64, now time.Time) nostr.Timestamp {
+	windowStart := now.Add(-popularWindow).Unix()
+	if watermark > windowStart {
+		return nostr.Timestamp(watermark)
+	}
+	return nostr.Timestamp(windowStart)
+}
+
+// persistPopularTally snapshots the tally every 5 minutes. Frequent enough
+// that a crash loses minutes rather than a day, cheap because only multi-
+// reactor targets are written.
+func persistPopularTally(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if err := popularTally.save(popularTallyPath(), now); err != nil {
+				log.Printf("popular: tally snapshot failed: %v", err)
+			}
+		}
+	}
+}

--- a/haven-go/popular_tally.go
+++ b/haven-go/popular_tally.go
@@ -166,7 +166,7 @@ func (t *engagementTally) add(ev *nostr.Event, now time.Time) {
 
 // dropSingletonsLocked frees room by discarding targets only one person
 // engaged with, oldest hour first. Those are ~78% of the map and cannot reach
-// minDistinctReactors before their hour rolls out of the window anyway.
+// minTrustedReactors before their hour rolls out of the window anyway.
 // Reports whether it freed anything.
 func (t *engagementTally) dropSingletonsLocked() bool {
 	indexes := make([]int64, 0, len(t.buckets))

--- a/haven-go/popular_tally_live_test.go
+++ b/haven-go/popular_tally_live_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package main
+
+// Live gate for the passive tally. Unit tests prove the bookkeeping; this
+// proves the thing actually collects: real seed relays, the real
+// ingestPopularEngagement loop, the real snapshot file.
+//
+//	go test ./ -tags integration -run TestLiveEngagementIngest -v -timeout 5m
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func TestLiveEngagementIngest(t *testing.T) {
+	const window = 90 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), window)
+	defer cancel()
+
+	pool = nostr.NewSimplePool(ctx, nostr.WithPenaltyBox())
+	config.PopularTallyEnabled = true
+	config.ImportSeedRelays = []string{
+		"wss://relay.primal.net",
+		"wss://nos.lol",
+		"wss://nostr.mom",
+		"wss://nostr-pub.wellorder.net",
+	}
+	config.PopularTallyCachePath = filepath.Join(t.TempDir(), "popular_tally.json")
+	popularTally = newEngagementTally()
+
+	start := time.Now()
+	ingestPopularEngagement(ctx) // returns when the context expires
+	t.Logf("ran for %s", time.Since(start).Round(time.Second))
+
+	now := time.Now()
+	targets, buckets := popularTally.stats(now)
+	coverage := popularTally.coverage(now)
+	snapshot := popularTally.snapshot(now)
+
+	var engagements int
+	for _, reactors := range snapshot {
+		engagements += len(reactors)
+	}
+	t.Logf("targets=%d buckets=%d engagements=%d coverage=%.4f (%.0fs of 24h)",
+		targets, buckets, engagements, coverage, coverage*popularWindow.Seconds())
+
+	if targets == 0 {
+		t.Fatal("no engagement collected from live relays in 90s — the ingest loop is not collecting")
+	}
+	if coverage <= 0 {
+		t.Fatal("coverage stayed at zero while the subscription was up")
+	}
+	// The point of the whole exercise: after a short cold start the tally can
+	// already answer Popular by itself, because the subscription's own history
+	// replay fills the window. If this drops below the floor, the read path
+	// falls back to the network and the redesign is buying nothing.
+	if coverage < popularTallyMinCoverage {
+		t.Errorf("after %s the tally covers only %.2f of the window, under the %.2f floor — Popular would still hit the network",
+			window, coverage, popularTallyMinCoverage)
+	}
+
+	// And it must produce actual eligible notes, not just raw counters.
+	eligible := rankTargets(snapshot, minDistinctReactors)
+	t.Logf("eligible notes at %d distinct reactors: %d", minDistinctReactors, len(eligible))
+	if len(eligible) == 0 {
+		t.Error("no note cleared the distinct-reactor floor — Popular would render empty")
+	}
+
+	if _, err := os.Stat(config.PopularTallyCachePath); err != nil {
+		t.Fatalf("no snapshot written on shutdown: %v", err)
+	}
+	restored := newEngagementTally()
+	restored.load(config.PopularTallyCachePath, now)
+	rt, _ := restored.stats(now)
+	t.Logf("snapshot restored %d targets (singletons are deliberately not written)", rt)
+}

--- a/haven-go/popular_tally_live_test.go
+++ b/haven-go/popular_tally_live_test.go
@@ -12,10 +12,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/nbd-wtf/go-nostr"
+
+	"github.com/barrydeen/haven/pkg/wot"
 )
 
 func TestLiveEngagementIngest(t *testing.T) {
@@ -67,8 +71,8 @@ func TestLiveEngagementIngest(t *testing.T) {
 	}
 
 	// And it must produce actual eligible notes, not just raw counters.
-	eligible := rankTargets(snapshot, minDistinctReactors)
-	t.Logf("eligible notes at %d distinct reactors: %d", minDistinctReactors, len(eligible))
+	eligible := rankTargets(snapshot, minTrustedReactors)
+	t.Logf("eligible notes at %d distinct reactors: %d", minTrustedReactors, len(eligible))
 	if len(eligible) == 0 {
 		t.Error("no note cleared the distinct-reactor floor — Popular would render empty")
 	}
@@ -80,4 +84,105 @@ func TestLiveEngagementIngest(t *testing.T) {
 	restored.load(config.PopularTallyCachePath, now)
 	rt, _ := restored.stats(now)
 	t.Logf("snapshot restored %d targets (singletons are deliberately not written)", rt)
+}
+
+// Live end-to-end gate for the web-of-trust filter: build the owner's real
+// graph off the relays, collect real engagement, and check that what survives
+// is both trustworthy and enough to fill a feed.
+//
+// Needs an owner pubkey to build a graph from; skipped without one:
+//
+//	HAVEN_TEST_OWNER_PUBKEY=<64-hex> go test ./ -tags integration \
+//	    -run TestLiveTrustGate -v -timeout 15m
+func TestLiveTrustGateLeavesAUsableFeed(t *testing.T) {
+	owner := os.Getenv("HAVEN_TEST_OWNER_PUBKEY")
+	if owner == "" {
+		t.Skip("set HAVEN_TEST_OWNER_PUBKEY to a 64-hex pubkey to run this")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	pool = nostr.NewSimplePool(ctx, nostr.WithPenaltyBox())
+	config.PopularTallyEnabled = true
+	config.ImportSeedRelays = []string{
+		"wss://relay.primal.net",
+		"wss://nos.lol",
+		"wss://nostr.mom",
+		"wss://nostr-pub.wellorder.net",
+	}
+	config.PopularTallyCachePath = filepath.Join(t.TempDir(), "popular_tally.json")
+	popularTally = newEngagementTally()
+
+	// Depth matters a lot here and the two platforms differ: level 2 is the
+	// owner's direct follows (the mobile default), level 3 adds their follows
+	// (the desktop default). Defaults to the desktop shape; override with
+	// HAVEN_TEST_WOT_DEPTH to see what a phone would show.
+	depth := 3
+	if v := os.Getenv("HAVEN_TEST_WOT_DEPTH"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			depth = parsed
+		}
+	}
+	model := wot.NewSimpleInMemory(pool, map[string]struct{}{owner: {}},
+		config.ImportSeedRelays, depth, 0, 60, filepath.Join(t.TempDir(), "wot.json"), 0)
+	graphStart := time.Now()
+	wot.Initialize(ctx, model, wot.NewCycle())
+	t.Logf("built a depth-%d graph of %d pubkeys in %s", depth, model.Size(), time.Since(graphStart).Round(time.Second))
+	if model.Size() == 0 {
+		t.Fatal("no graph built — cannot judge the gate")
+	}
+
+	ingestCtx, ingestCancel := context.WithTimeout(ctx, 90*time.Second)
+	defer ingestCancel()
+	ingestPopularEngagement(ingestCtx)
+
+	now := time.Now()
+	tally := popularTally.snapshot(now)
+	ungated := rankTargets(tally, minTrustedReactors)
+	gated := rankTargets(filterToTrusted(ctx, model, tally), minTrustedReactors)
+	t.Logf("candidates: %d targets -> %d eligible ungated, %d eligible through the trust gate",
+		len(tally), len(ungated), len(gated))
+
+	// The risk of this filter is over-filtering: a feed nobody can read is
+	// not an improvement on a feed full of spam.
+	if len(gated) < 10 {
+		t.Errorf("only %d notes survived the trust gate — the feed would be near-empty", len(gated))
+	}
+
+	// Nothing may survive on untrusted engagement.
+	for _, r := range gated {
+		trusted := 0
+		for pk := range tally[r.id] {
+			if model.Has(ctx, pk) {
+				trusted++
+			}
+		}
+		if trusted < minTrustedReactors {
+			t.Fatalf("note %s survived with %d trusted reactors, floor is %d", r.id[:8], trusted, minTrustedReactors)
+		}
+	}
+
+	// Diagnostic, not an assertion: what share of each list is the campaign
+	// that prompted this work. Asserting on its text would tie the suite to
+	// one spammer's copy.
+	top := func(ranked []scoredTarget, n int) []string {
+		ids := []string{}
+		for _, r := range ranked {
+			if len(ids) == n {
+				break
+			}
+			ids = append(ids, r.id)
+		}
+		return ids
+	}
+	for label, ids := range map[string][]string{"ungated": top(ungated, 20), "gated": top(gated, 20)} {
+		hits := 0
+		for _, ev := range resolveNoteBodies(ctx, ids) {
+			if strings.Contains(ev.Content, "In this week's issue") {
+				hits++
+			}
+		}
+		t.Logf("%s top 20: %d notes from the 'In this week's issue' campaign", label, hits)
+	}
 }

--- a/haven-go/popular_tally_test.go
+++ b/haven-go/popular_tally_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/nbd-wtf/go-nostr"
+
+	"github.com/barrydeen/haven/pkg/wot"
 )
 
 func engagement(kind int, reactor, target string, at time.Time) *nostr.Event {
@@ -65,8 +67,8 @@ func TestTallyRankingMatchesBatch(t *testing.T) {
 		t.Fatalf("bucketed tally disagrees with batch map:\n%d targets vs %d", len(batch), len(merged))
 	}
 
-	wantRanked := rankTargets(batch, minDistinctReactors)
-	gotRanked := rankTargets(merged, minDistinctReactors)
+	wantRanked := rankTargets(batch, minTrustedReactors)
+	gotRanked := rankTargets(merged, minTrustedReactors)
 	if !reflect.DeepEqual(wantRanked, gotRanked) {
 		t.Fatalf("ranking differs: batch %v vs tally %v", wantRanked, gotRanked)
 	}
@@ -207,8 +209,8 @@ func TestSnapshotRoundTripPreservesRanking(t *testing.T) {
 	restored := newEngagementTally()
 	restored.load(path, now)
 
-	want := rankTargets(original.snapshot(now), minDistinctReactors)
-	got := rankTargets(restored.snapshot(now), minDistinctReactors)
+	want := rankTargets(original.snapshot(now), minTrustedReactors)
+	got := rankTargets(restored.snapshot(now), minTrustedReactors)
 	if len(want) == 0 {
 		t.Fatal("test data produced no eligible notes — it would pass vacuously")
 	}
@@ -414,7 +416,7 @@ func TestTallyConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 200; i++ {
-				_ = rankTargets(tally.snapshot(now), minDistinctReactors)
+				_ = rankTargets(tally.snapshot(now), minTrustedReactors)
 				_ = tally.coverage(now)
 				tally.stats(now)
 			}
@@ -484,6 +486,10 @@ func withStubbedFetch(t *testing.T, hours int) *bool {
 	popularTally = newEngagementTally()
 	pool = nil
 	config.ImportSeedRelays = nil
+	// Install a graph explicitly: the wot instance is process-wide and other
+	// test files install their own, so inheriting whatever ran first makes
+	// these tests pass or fail on ordering rather than on the code.
+	wot.MarkReady(wot.NewCycle(), stubWot{allow: true})
 	popularCacheMu.Lock()
 	popularCache, popularCacheExpiry = nil, time.Time{}
 	popularCacheMu.Unlock()
@@ -497,7 +503,7 @@ func withStubbedFetch(t *testing.T, hours int) *bool {
 	for hour := 0; hour < hours; hour++ {
 		at := now.Add(-time.Duration(hour)*time.Hour - time.Minute)
 		for target := 0; target < popularBucketMinTargets; target++ {
-			for reactor := 0; reactor < minDistinctReactors+1; reactor++ {
+			for reactor := 0; reactor < minTrustedReactors+1; reactor++ {
 				tgt := fmt.Sprintf("note%d-%d", hour, target)
 				popularTally.add(engagement(7, fmt.Sprintf("pk%d", reactor), tgt, at), now)
 			}

--- a/haven-go/popular_tally_test.go
+++ b/haven-go/popular_tally_test.go
@@ -1,0 +1,507 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func engagement(kind int, reactor, target string, at time.Time) *nostr.Event {
+	return &nostr.Event{
+		Kind:      kind,
+		PubKey:    reactor,
+		Tags:      nostr.Tags{{"e", target}},
+		CreatedAt: nostr.Timestamp(at.Unix()),
+	}
+}
+
+// randomEngagementSet builds a spread of events across the whole window, with
+// repeat reactors, mixed kinds, and notes both over and under the floor.
+func randomEngagementSet(now time.Time, n int) []*nostr.Event {
+	rng := rand.New(rand.NewSource(1))
+	kinds := []int{7, 6, 9735}
+	events := make([]*nostr.Event, 0, n)
+	for i := 0; i < n; i++ {
+		target := fmt.Sprintf("note%d", rng.Intn(40))
+		reactor := fmt.Sprintf("pk%d", rng.Intn(25))
+		age := time.Duration(rng.Intn(23*60)) * time.Minute
+		events = append(events, engagement(kinds[rng.Intn(len(kinds))], reactor, target, now.Add(-age)))
+	}
+	return events
+}
+
+// THE load-bearing test: splitting the 24h window into hour buckets must not
+// change a single score. Same events, two paths — the batch map dvm.go builds
+// and a merged snapshot of the bucketed tally — must rank identically.
+//
+// Mutation-checked: raising popularBucketSpan handling to file everything in
+// one bucket keeps this green (correctly — that is still equivalent), but
+// changing snapshot's merge from "strongest weight wins" to "last write wins"
+// or "sum" makes it fail, which is the drift it exists to catch.
+func TestTallyRankingMatchesBatch(t *testing.T) {
+	now := time.Now()
+	events := randomEngagementSet(now, 3000)
+
+	batch := map[string]map[string]float64{}
+	for _, ev := range events {
+		addEngagement(batch, ev)
+	}
+
+	tally := newEngagementTally()
+	for _, ev := range events {
+		tally.add(ev, now)
+	}
+	merged := tally.snapshot(now)
+
+	if !reflect.DeepEqual(batch, merged) {
+		t.Fatalf("bucketed tally disagrees with batch map:\n%d targets vs %d", len(batch), len(merged))
+	}
+
+	wantRanked := rankTargets(batch, minDistinctReactors)
+	gotRanked := rankTargets(merged, minDistinctReactors)
+	if !reflect.DeepEqual(wantRanked, gotRanked) {
+		t.Fatalf("ranking differs: batch %v vs tally %v", wantRanked, gotRanked)
+	}
+	if len(wantRanked) == 0 {
+		t.Fatal("test data produced no eligible notes — it would pass vacuously")
+	}
+}
+
+// Arrival order is not something a live subscription controls: relays replay
+// at different offsets and reconnects re-deliver. Feeding the same events in a
+// different order must produce the same tally.
+func TestTallyIsOrderIndependent(t *testing.T) {
+	now := time.Now()
+	events := randomEngagementSet(now, 1500)
+
+	forward := newEngagementTally()
+	for _, ev := range events {
+		forward.add(ev, now)
+	}
+	backward := newEngagementTally()
+	for i := len(events) - 1; i >= 0; i-- {
+		backward.add(events[i], now)
+	}
+
+	if !reflect.DeepEqual(forward.snapshot(now), backward.snapshot(now)) {
+		t.Fatal("tally depends on the order events arrive in")
+	}
+}
+
+// Anything older than the window is dropped, and the drop is by clock hour so
+// the edge is exact rather than approximate.
+func TestTallyEvictsOutsideWindow(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+
+	tally.add(engagement(7, "alice", "fresh", now.Add(-time.Minute)), now)
+	tally.add(engagement(7, "alice", "old", now.Add(-23*time.Hour)), now)
+
+	if got := tally.snapshot(now); len(got) != 2 {
+		t.Fatalf("before the roll: %d targets, want 2", len(got))
+	}
+
+	// Two hours later the 23h-old engagement is outside the window.
+	later := now.Add(2 * time.Hour)
+	got := tally.snapshot(later)
+	if _, ok := got["old"]; ok {
+		t.Error("engagement older than the window survived the roll")
+	}
+	if _, ok := got["fresh"]; !ok {
+		t.Error("engagement inside the window was evicted")
+	}
+}
+
+// created_at is attacker-controlled. A note stamped into next week must not be
+// filed in a bucket the window never reaches.
+func TestTallyRejectsSkewedTimestamps(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+
+	tally.add(engagement(7, "alice", "future", now.Add(7*24*time.Hour)), now)
+	tally.add(engagement(7, "alice", "ancient", now.Add(-72*time.Hour)), now)
+	tally.add(engagement(7, "alice", "ok", now.Add(-time.Minute)), now)
+
+	got := tally.snapshot(now)
+	if _, ok := got["future"]; ok {
+		t.Error("a future-dated engagement was accepted")
+	}
+	if _, ok := got["ancient"]; ok {
+		t.Error("an engagement older than the window was accepted")
+	}
+	if _, ok := got["ok"]; !ok {
+		t.Error("a valid engagement was rejected")
+	}
+}
+
+// Coverage measures how long the subscription was actually up. A process that
+// was asleep for hours between two marks must not claim that time as watched —
+// otherwise a phone would skip the backfill it needs.
+func TestCoverageCreditsOnlyConnectedTime(t *testing.T) {
+	base := time.Now().Truncate(time.Hour).Add(30 * time.Minute)
+	tally := newEngagementTally()
+
+	tally.markAlive(base)
+	tally.markAlive(base.Add(6 * time.Hour)) // long sleep: capped, not credited
+
+	if got := tally.coverage(base.Add(6 * time.Hour)); got > popularCoverageMaxStep.Seconds()/popularWindow.Seconds()+1e-9 {
+		t.Fatalf("a six-hour gap was credited as coverage: %.4f", got)
+	}
+
+	// A steady stream of marks accrues real coverage.
+	steady := newEngagementTally()
+	at := base
+	for i := 0; i < 120; i++ { // one hour of 30s marks
+		steady.markAlive(at)
+		at = at.Add(popularCoverageMarkEvery)
+	}
+	got := steady.coverage(at)
+	want := time.Hour.Seconds() / popularWindow.Seconds()
+	if got < want*0.9 || got > want*1.1 {
+		t.Fatalf("one hour of marks gave coverage %.4f, want about %.4f", got, want)
+	}
+}
+
+// No bucket may record more than the hour it covers, however many marks land.
+func TestCoverageCannotExceedTheHour(t *testing.T) {
+	base := time.Now().Truncate(time.Hour)
+	tally := newEngagementTally()
+	at := base
+	for i := 0; i < 500; i++ {
+		tally.markAlive(at)
+		at = at.Add(time.Second)
+	}
+	tally.mu.Lock()
+	defer tally.mu.Unlock()
+	if got := tally.covered[bucketIndex(base)]; got > popularBucketSpan.Seconds() {
+		t.Fatalf("bucket recorded %.0f seconds of coverage in a %.0f second hour", got, popularBucketSpan.Seconds())
+	}
+}
+
+// The snapshot file exists so Popular is not empty after a relaunch. What it
+// must preserve is the ranking, not every byte: singletons are deliberately
+// dropped.
+func TestSnapshotRoundTripPreservesRanking(t *testing.T) {
+	now := time.Now()
+	path := filepath.Join(t.TempDir(), "popular_tally.json")
+
+	original := newEngagementTally()
+	for _, ev := range randomEngagementSet(now, 2000) {
+		original.add(ev, now)
+	}
+	original.markAlive(now.Add(-time.Minute))
+	original.markAlive(now)
+
+	if err := original.save(path, now); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	restored := newEngagementTally()
+	restored.load(path, now)
+
+	want := rankTargets(original.snapshot(now), minDistinctReactors)
+	got := rankTargets(restored.snapshot(now), minDistinctReactors)
+	if len(want) == 0 {
+		t.Fatal("test data produced no eligible notes — it would pass vacuously")
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("ranking changed across a save/load:\nwant %v\ngot  %v", want, got)
+	}
+}
+
+// A snapshot written yesterday must not resurrect yesterday's popularity.
+func TestSnapshotLoadDropsStaleBuckets(t *testing.T) {
+	now := time.Now()
+	path := filepath.Join(t.TempDir(), "popular_tally.json")
+
+	old := newEngagementTally()
+	for i := 0; i < 6; i++ {
+		old.add(engagement(7, fmt.Sprintf("pk%d", i), "yesterday", now.Add(-time.Hour)), now)
+	}
+	if err := old.save(path, now); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Reload a full day later.
+	restored := newEngagementTally()
+	restored.load(path, now.Add(25*time.Hour))
+	if got := restored.snapshot(now.Add(25 * time.Hour)); len(got) != 0 {
+		t.Fatalf("stale buckets survived the reload: %v", got)
+	}
+}
+
+// A truncated or corrupt file must leave the tally usable and empty, not panic
+// and not half-load: the read path backfills from the network in that case.
+func TestSnapshotLoadToleratesGarbage(t *testing.T) {
+	now := time.Now()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "popular_tally.json")
+	if err := os.WriteFile(path, []byte(`{"buckets":{"1":{"note`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tally := newEngagementTally()
+	tally.load(path, now)
+	if got := tally.snapshot(now); len(got) != 0 {
+		t.Fatalf("garbage file produced %d targets", len(got))
+	}
+	tally.add(engagement(7, "alice", "note1", now), now)
+	if got := tally.snapshot(now); len(got) != 1 {
+		t.Fatal("tally unusable after loading a corrupt snapshot")
+	}
+}
+
+// The ceiling must shed the notes that cannot win — targets one person
+// touched — and keep the ones that can. It also has to be a ceiling on the
+// whole window: an earlier version capped each hour bucket, which bounded
+// nothing, because 24 buckets each just under the cap hold 24 times what the
+// number claims.
+func TestCeilingDropsSingletonsAndBoundsTheWindow(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+
+	// A contender: six distinct reactors, comfortably over the floor.
+	for i := 0; i < 6; i++ {
+		tally.add(engagement(7, fmt.Sprintf("fan%d", i), "contender", now), now)
+	}
+	// Then flood every hour of the window with singletons, well past the cap.
+	for i := 0; i < popularMaxTargets*2; i++ {
+		at := now.Add(-time.Duration(i%24) * time.Hour).Add(-time.Minute)
+		tally.add(engagement(7, fmt.Sprintf("drive%d", i), fmt.Sprintf("junk%d", i), at), now)
+	}
+
+	got := tally.snapshot(now)
+	if _, ok := got["contender"]; !ok {
+		t.Fatal("the multi-reactor note was evicted by a flood of singletons")
+	}
+	if len(got) > popularMaxTargets {
+		t.Fatalf("tally holds %d targets across the window, past the %d ceiling", len(got), popularMaxTargets)
+	}
+}
+
+// The bookkeeping counter behind that ceiling must track what is really held.
+// If it drifts up, the tally throttles itself early and stops collecting; if it
+// drifts down, the ceiling stops being one.
+func TestTotalTracksHeldTargets(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+	for _, ev := range randomEngagementSet(now, 4000) {
+		tally.add(ev, now)
+	}
+	check := func(when string, at time.Time) {
+		t.Helper()
+		held := len(tally.snapshot(at))
+		tally.mu.Lock()
+		counted := 0
+		for _, bucket := range tally.buckets {
+			counted += len(bucket)
+		}
+		total := tally.total
+		tally.mu.Unlock()
+		if total != counted {
+			t.Fatalf("%s: counter says %d target entries, buckets hold %d", when, total, counted)
+		}
+		if held > total {
+			t.Fatalf("%s: %d distinct targets from %d entries", when, held, total)
+		}
+	}
+	check("after fill", now)
+	check("after a 12h roll", now.Add(12*time.Hour))
+	check("after the window rolls fully", now.Add(25*time.Hour))
+}
+
+// engagementWeight is the single definition both paths score from; if it drifts
+// the anti-gaming ordering (zap > repost > like) goes with it.
+func TestEngagementWeightOrdering(t *testing.T) {
+	if !(engagementWeight(9735) > engagementWeight(6) && engagementWeight(6) > engagementWeight(7)) {
+		t.Fatal("zap > repost > reaction no longer holds")
+	}
+	for _, kind := range []int{0, 1, 3, 30023, 1063} {
+		if engagementWeight(kind) != 0 {
+			t.Errorf("kind %d scored %v, want 0", kind, engagementWeight(kind))
+		}
+	}
+}
+
+// A cold start collects most of a day inside the first minute, because relays
+// replay history when the subscription opens with a 24h `since`. Coverage must
+// see that data even though the process has almost no uptime — otherwise the
+// read path pays for a network fetch to re-collect what it is already holding.
+func TestCoverageCountsReplayedHistory(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+
+	// One minute of "uptime", 24 hours of replayed engagement.
+	tally.markAlive(now.Add(-time.Minute))
+	tally.markAlive(now)
+	for hour := 0; hour < 24; hour++ {
+		at := now.Add(-time.Duration(hour)*time.Hour - time.Minute)
+		for target := 0; target < popularBucketMinTargets; target++ {
+			tally.add(engagement(7, fmt.Sprintf("pk%d-%d", hour, target), fmt.Sprintf("note%d-%d", hour, target), at), now)
+		}
+	}
+
+	if got := tally.coverage(now); got < popularTallyMinCoverage {
+		t.Fatalf("a tally holding 24h of replayed engagement reported %.2f coverage, under the %.2f floor", got, popularTallyMinCoverage)
+	}
+}
+
+// The data measure must not be satisfied by a scatter of stray events, or a
+// device that saw almost nothing would answer Popular from almost nothing.
+func TestSparseDataDoesNotClaimCoverage(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+	for hour := 0; hour < 24; hour++ {
+		at := now.Add(-time.Duration(hour)*time.Hour - time.Minute)
+		tally.add(engagement(7, fmt.Sprintf("pk%d", hour), fmt.Sprintf("note%d", hour), at), now)
+	}
+	if got := tally.coverage(now); got >= popularTallyMinCoverage {
+		t.Fatalf("one event per hour claimed %.2f coverage", got)
+	}
+}
+
+// A reconnect must resume from the newest event already seen, not re-request
+// the whole window — but a watermark that has aged out of the window must fall
+// back to the window start, or a device that was off for two days would resume
+// from a point the tally can no longer hold.
+func TestIngestSinceResumesFromWatermark(t *testing.T) {
+	now := time.Now()
+	windowStart := now.Add(-popularWindow).Unix()
+
+	if got := ingestSince(0, now); int64(got) != windowStart {
+		t.Errorf("first pass resumed at %d, want the window start %d", got, windowStart)
+	}
+	recent := now.Add(-5 * time.Minute).Unix()
+	if got := ingestSince(recent, now); int64(got) != recent {
+		t.Errorf("reconnect resumed at %d, want the watermark %d", got, recent)
+	}
+	stale := now.Add(-48 * time.Hour).Unix()
+	if got := ingestSince(stale, now); int64(got) != windowStart {
+		t.Errorf("stale watermark resumed at %d, want the window start %d", got, windowStart)
+	}
+}
+
+// The tally is written by the ingest loop and read by whichever thread opened
+// the Popular tab, while a ticker snapshots it to disk. Run all three at once
+// under -race; an unsynchronised map here is a hard crash in production, not a
+// wrong answer.
+func TestTallyConcurrentAccess(t *testing.T) {
+	now := time.Now()
+	tally := newEngagementTally()
+	path := filepath.Join(t.TempDir(), "popular_tally.json")
+
+	var wg sync.WaitGroup
+	for writer := 0; writer < 4; writer++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				tally.add(engagement(7, fmt.Sprintf("pk%d-%d", w, i%20), fmt.Sprintf("note%d", i%50), now), now)
+				tally.markAlive(now)
+			}
+		}(writer)
+	}
+	for reader := 0; reader < 2; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				_ = rankTargets(tally.snapshot(now), minDistinctReactors)
+				_ = tally.coverage(now)
+				tally.stats(now)
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			if err := tally.save(path, now); err != nil {
+				t.Errorf("save under concurrent load: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	if got := len(tally.snapshot(now)); got != 50 {
+		t.Fatalf("concurrent writers produced %d targets, want 50", got)
+	}
+}
+
+// Popular must be answered from the tally alone once it covers the window —
+// no network call at all. The stub records whether the read path reached for
+// one, because "no error" alone cannot tell a local answer apart from a failed
+// fetch whose error was swallowed.
+func TestPopularServesLocallyWithoutFetching(t *testing.T) {
+	fetched := withStubbedFetch(t, 24) // a full window of engagement
+	if _, err := computePopularNotes(context.Background()); err != nil {
+		t.Fatalf("computePopularNotes: %v", err)
+	}
+	if *fetched {
+		t.Fatal("a fully covered tally still fetched engagement from the network")
+	}
+}
+
+// And the other half of the gate: a tally that covers almost nothing must
+// backfill, or a phone the OS keeps suspending would rank a day of nostr from
+// the ten minutes it happened to be awake.
+func TestThinTallyBackfillsFromNetwork(t *testing.T) {
+	fetched := withStubbedFetch(t, 1) // one hour of engagement, far under the floor
+	if _, err := computePopularNotes(context.Background()); err != nil {
+		t.Fatalf("computePopularNotes: %v", err)
+	}
+	if !*fetched {
+		t.Fatal("a tally covering one hour of the window answered without backfilling")
+	}
+}
+
+// withStubbedFetch points the read path at a stub, fills the tally with
+// `hours` of eligible engagement, and restores every global it touched.
+// Returns the flag the stub sets.
+func withStubbedFetch(t *testing.T, hours int) *bool {
+	t.Helper()
+	now := time.Now()
+
+	savedTally, savedPool, savedRelays := popularTally, pool, config.ImportSeedRelays
+	savedFetch := fetchEngagementInto
+	t.Cleanup(func() {
+		popularTally, pool, config.ImportSeedRelays = savedTally, savedPool, savedRelays
+		fetchEngagementInto = savedFetch
+		popularCacheMu.Lock()
+		popularCache, popularCacheExpiry = nil, time.Time{}
+		popularCacheMu.Unlock()
+	})
+
+	popularTally = newEngagementTally()
+	pool = nil
+	config.ImportSeedRelays = nil
+	popularCacheMu.Lock()
+	popularCache, popularCacheExpiry = nil, time.Time{}
+	popularCacheMu.Unlock()
+
+	fetched := false
+	fetchEngagementInto = func(context.Context, map[string]map[string]float64) error {
+		fetched = true
+		return nil
+	}
+
+	for hour := 0; hour < hours; hour++ {
+		at := now.Add(-time.Duration(hour)*time.Hour - time.Minute)
+		for target := 0; target < popularBucketMinTargets; target++ {
+			for reactor := 0; reactor < minDistinctReactors+1; reactor++ {
+				tgt := fmt.Sprintf("note%d-%d", hour, target)
+				popularTally.add(engagement(7, fmt.Sprintf("pk%d", reactor), tgt, at), now)
+			}
+		}
+	}
+	return &fetched
+}

--- a/haven-go/popular_trust_test.go
+++ b/haven-go/popular_trust_test.go
@@ -1,0 +1,164 @@
+package main
+
+// Tests for the web-of-trust gate on the Popular feed.
+//
+// Note on shared state: wot's instance is a process-wide atomic.Value, and
+// other test files in this package install their own graph into it. Every test
+// here therefore installs the graph it needs rather than assuming one — the
+// first version of these tests passed only because negsync_test.go happened to
+// have left an allow-everyone stub behind, and failed the moment they were run
+// with -run.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/barrydeen/haven/pkg/wot"
+)
+
+// installGraph makes the given pubkeys the owner's web of trust for this test.
+func installGraph(t *testing.T, members ...string) {
+	t.Helper()
+	set := make(map[string]bool, len(members))
+	for _, pk := range members {
+		set[pk] = true
+	}
+	wot.MarkReady(wot.NewCycle(), stubWot{members: set})
+}
+
+// installOpenGraph installs the WOT_DEPTH=0 shape: a model that vouches for
+// everyone. The gate must then be a no-op, not a wall.
+func installOpenGraph(t *testing.T) {
+	t.Helper()
+	wot.MarkReady(wot.NewCycle(), stubWot{allow: true})
+}
+
+// installEmptyGraph installs the cold-start shape: a real graph with nothing
+// in it yet, which answers false for every pubkey.
+func installEmptyGraph(t *testing.T) {
+	t.Helper()
+	wot.MarkReady(wot.NewCycle(), stubWot{members: map[string]bool{}})
+}
+
+// The shape of the real campaign, in miniature: a note boosted by a hundred
+// accounts nobody knows, against one carried by three the owner's network
+// vouches for. The manufactured audience is the larger number and must lose.
+func TestTrustGateDropsManufacturedEngagement(t *testing.T) {
+	ctx := context.Background()
+	trusted := []string{"friend1", "friend2", "friend3"}
+	installGraph(t, trusted...)
+
+	tally := map[string]map[string]float64{}
+	for i := 0; i < 100; i++ {
+		addEngagement(tally, engagement(7, fmt.Sprintf("bot%d", i), "campaign", time.Now()))
+	}
+	for _, pk := range trusted {
+		addEngagement(tally, engagement(7, pk, "genuine", time.Now()))
+	}
+
+	// Ungated, the campaign wins by a mile — that is today's feed.
+	if ranked := rankTargets(tally, minTrustedReactors); len(ranked) == 0 || ranked[0].id != "campaign" {
+		t.Fatalf("test setup: ungated ranking should favour the campaign, got %v", ranked)
+	}
+
+	model, ok := trustGraph(ctx)
+	if !ok {
+		t.Fatal("installed graph reported unusable")
+	}
+	ranked := rankTargets(filterToTrusted(ctx, model, tally), minTrustedReactors)
+	if len(ranked) != 1 || ranked[0].id != "genuine" {
+		t.Fatalf("trust gate produced %v, want only the genuine note", ranked)
+	}
+}
+
+// Trusted engagement still has to clear the floor: two friends is not a
+// popular note, it is two friends.
+func TestTrustedEngagementStillNeedsTheFloor(t *testing.T) {
+	ctx := context.Background()
+	installGraph(t, "friend1", "friend2")
+
+	tally := map[string]map[string]float64{}
+	for _, pk := range []string{"friend1", "friend2"} {
+		addEngagement(tally, engagement(7, pk, "note", time.Now()))
+	}
+	for i := 0; i < 50; i++ {
+		addEngagement(tally, engagement(7, fmt.Sprintf("bot%d", i), "note", time.Now()))
+	}
+
+	model, _ := trustGraph(ctx)
+	if ranked := rankTargets(filterToTrusted(ctx, model, tally), minTrustedReactors); len(ranked) != 0 {
+		t.Fatalf("a note with %d trusted reactors ranked at a floor of %d: %v",
+			2, minTrustedReactors, ranked)
+	}
+}
+
+// A note left with no trusted engagement at all must leave the map entirely,
+// not linger as an empty entry that still counts as a candidate.
+func TestFilterToTrustedDropsEmptiedTargets(t *testing.T) {
+	ctx := context.Background()
+	installGraph(t, "friend1")
+
+	tally := map[string]map[string]float64{}
+	addEngagement(tally, engagement(7, "friend1", "kept", time.Now()))
+	addEngagement(tally, engagement(7, "stranger", "dropped", time.Now()))
+
+	got := filterToTrusted(ctx, stubWot{members: map[string]bool{"friend1": true}}, tally)
+	if _, ok := got["dropped"]; ok {
+		t.Error("a note with no trusted engagement survived the filter")
+	}
+	if len(got["kept"]) != 1 {
+		t.Errorf("trusted engagement was lost: %v", got["kept"])
+	}
+}
+
+// Cold start must withhold the feed, not fall back to the open firehose —
+// that fallback is exactly how the spam gets in. It must also withhold before
+// paying for a network fetch.
+func TestPopularWithholdsFeedUntilGraphIsReady(t *testing.T) {
+	fetched := withStubbedFetch(t, 24)
+	installEmptyGraph(t)
+
+	notes, err := computePopularNotes(context.Background())
+	if err != nil {
+		t.Fatalf("computePopularNotes: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("an unbuilt trust graph served %d notes", len(notes))
+	}
+	if *fetched {
+		t.Error("withheld the feed but still paid for a network fetch")
+	}
+}
+
+// Has() answers false both for an untrusted pubkey and for a graph that does
+// not exist yet, so usability cannot be read off Has alone.
+func TestTrustGraphUsableTellsColdStartFromStrangers(t *testing.T) {
+	ctx := context.Background()
+
+	installEmptyGraph(t)
+	if _, ok := trustGraph(ctx); ok {
+		t.Error("an empty graph reported usable")
+	}
+
+	installGraph(t, "friend1", "friend2")
+	if _, ok := trustGraph(ctx); !ok {
+		t.Error("a populated graph reported unusable")
+	}
+
+	// WOT_DEPTH=0: the owner turned the graph off, and Has vouches for
+	// everyone. The gate must stand down rather than blank the feed.
+	installOpenGraph(t)
+	model, ok := trustGraph(ctx)
+	if !ok {
+		t.Fatal("a deliberately disabled graph blanked the feed")
+	}
+	tally := map[string]map[string]float64{}
+	for i := 0; i < minTrustedReactors; i++ {
+		addEngagement(tally, engagement(7, fmt.Sprintf("anyone%d", i), "note", time.Now()))
+	}
+	if got := filterToTrusted(ctx, model, tally); len(got["note"]) != minTrustedReactors {
+		t.Errorf("disabled graph dropped engagement: %v", got)
+	}
+}


### PR DESCRIPTION
Implements the scoped issue "Popular feed: passive tally from live relay stream instead of on-demand DVM query".

## Why, measured

Popular fired a fresh REQ at the seed relays on every open past its 5-minute cache. Against the shipped seed relays, three of the four that answered returned **500 events each regardless of our `Limit: 5000`**, oldest 28–40 minutes old. So "Popular over the last 24 hours" was really "the last half hour those relays felt like returning" — a ceiling no change on our side can raise.

Cold-start measurement of the new loop against the same relays: **90 seconds of ingestion filled all 24 hour buckets with 12.3k engagements over 3.5k targets, yielding 148 notes over the five-distinct-reactor floor — against 90 from the equivalent one-shot query.** Relays replay history when a subscription opens with a 24h `since`, so the tally is useful almost immediately, not after a day of uptime.

## What changed

- `haven-go/popular_tally.go` — live subscription to kinds 7/6/9735, rolling 24h tally in hour buckets, snapshot file, coverage tracking. Loop shape copied from the inbox subscription in `import.go` (reconnect with capped backoff).
- `haven-go/dvm.go` — the read path scores the tally; below the coverage floor it still fetches, folding the result into the same tally rather than replacing it. Note bodies resolve from local stores first, network only for what is missing.
- Wired into both start paths (`main.go`, `cshared.go`), gated by `POPULAR_TALLY_ENABLED` (default on).

**Scoring is unchanged** — `addEngagement`, `rankTargets`, `scoreExcludingAuthor`, `capPerAuthor` are used as-is, and `TestTallyRankingMatchesBatch` pins the bucketed tally to the old batch map event-for-event. **No client change**: all three platforms call `ComputePopularNotesC` and its JSON contract is untouched.

## Mobile

"Always running" is true on Mac and false on a phone. Coverage is the larger of *uptime* and *how many hour buckets hold real data*, so a suspended-and-resumed phone gets credit for the history its reconnect replays, and falls back to the network when it genuinely has thin data.

## Bounds

| | |
|---|---|
| A real day of engagement | 4 MB |
| 10× that load | 13 MB (ceiling sheds singletons) |
| Ceiling | 25k targets across the **window**, not per bucket |

Reactor pubkeys are stored whole and interned — truncating them (my first design) silently weakens `scoreExcludingAuthor`, which excludes a note's own author by comparing that key.

## Verification

- 49 tests pass under `-race`; `go vet` clean.
- Live gate: `go test ./ -tags integration -run TestLiveEngagementIngest` runs the real loop against real relays and asserts it can answer Popular locally. Green on three consecutive runs.
- Every gate was mutation-checked. Two defects that found: the snapshot's singleton filter ran per bucket and discarded exactly the notes Popular exists for (a note with six reactors across six hours looks like a singleton in each), and the first "answers locally" test passed against code that always fetched, because the fetch error was swallowed when the tally was non-empty — it now observes the fetch itself.

CHANGELOG deliberately untouched; this is not a release entry yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)