### PR TITLE
Android: relay dashboard gets a Stop button and shows its address

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/DashboardScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/DashboardScreen.kt
@@ -2132,6 +2132,7 @@ fun DashboardScreen(
                 mediaSize = mediaSize,
                 isLoading = statsLoading,
                 relayStatus = currentRelayStatus,
+                relayAddress = currentConfig.nostrURL,
                 isLocked = currentIsLocked,
                 isPortConflict = currentIsPortConflict,
                 onRefresh = viewModel::loadStats,
@@ -2670,6 +2671,7 @@ private fun DashboardSheetContent(
     mediaSize: String,
     isLoading: Boolean,
     relayStatus: RelayForegroundService.RelayStatus,
+    relayAddress: String?,
     isLocked: Boolean,
     isPortConflict: Boolean,
     onRefresh: () -> Unit,
@@ -2775,6 +2777,7 @@ private fun DashboardSheetContent(
         // Relay status header
         com.nostrvault.ui.screens.dashboard.RelayStatusHeader(
             relayStatus = relayStatus,
+            relayAddress = relayAddress,
             isLocked = isLocked,
             isPortConflict = isPortConflict,
             onStartRelay = onStartRelay,

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/dashboard/RelayStatusHeader.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/dashboard/RelayStatusHeader.kt
@@ -1,8 +1,11 @@
 package com.nostrvault.ui.screens.dashboard
 
+import android.widget.Toast
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,6 +15,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -22,6 +30,7 @@ import com.nostrvault.ui.theme.*
 @Composable
 fun RelayStatusHeader(
     relayStatus: RelayStatus,
+    relayAddress: String?,
     isLocked: Boolean,
     isPortConflict: Boolean,
     onStartRelay: () -> Unit,
@@ -31,6 +40,8 @@ fun RelayStatusHeader(
     onClearLocks: () -> Unit,
 ) {
     val colors = LocalNostrVaultColors.current
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
 
     val statusColor = when (relayStatus) {
         RelayStatus.RUNNING -> SuccessGreen
@@ -100,6 +111,23 @@ fun RelayStatusHeader(
                         fontWeight = FontWeight.Bold,
                         fontFamily = FontFamily.Monospace,
                     )
+
+                    // The single most useful thing on a screen named after the
+                    // relay: where it actually is. Was nowhere on this screen.
+                    if (relayAddress != null) {
+                        Text(
+                            text = relayAddress,
+                            color = SecondaryText,
+                            fontSize = 12.sp,
+                            fontFamily = FontFamily.Monospace,
+                            modifier = Modifier
+                                .clickable {
+                                    clipboard.setText(AnnotatedString(relayAddress))
+                                    Toast.makeText(context, "Address copied", Toast.LENGTH_SHORT).show()
+                                }
+                                .semantics { contentDescription = "Relay address: $relayAddress. Tap to copy." },
+                        )
+                    }
                 }
 
                 // Control button
@@ -122,18 +150,36 @@ fun RelayStatusHeader(
                         }
                     }
                     RelayStatus.RUNNING -> {
-                        OutlinedButton(
-                            onClick = onRestartRelay,
-                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                        ) {
-                            Icon(
-                                NostrVaultIcons.Refresh,
-                                contentDescription = null,
-                                tint = colors.primary,
-                                modifier = Modifier.size(16.dp),
-                            )
-                            Spacer(Modifier.width(4.dp))
-                            Text("Restart", fontSize = 13.sp, color = colors.primary)
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            // Stop was already reachable from Advanced Settings and
+                            // the persistent notification, just not from the screen
+                            // named after the relay.
+                            OutlinedButton(
+                                onClick = onStopRelay,
+                                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                            ) {
+                                Icon(
+                                    NostrVaultIcons.Stop,
+                                    contentDescription = null,
+                                    tint = SecondaryText,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text("Stop", fontSize = 13.sp, color = SecondaryText)
+                            }
+                            OutlinedButton(
+                                onClick = onRestartRelay,
+                                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                            ) {
+                                Icon(
+                                    NostrVaultIcons.Refresh,
+                                    contentDescription = null,
+                                    tint = colors.primary,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Text("Restart", fontSize = 13.sp, color = colors.primary)
+                            }
                         }
                     }
                     RelayStatus.BOOTING, RelayStatus.IMPORTING -> {

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/dashboard/RelayStatusHeader.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/dashboard/RelayStatusHeader.kt
@@ -4,7 +4,6 @@ import android.widget.Toast
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
@@ -115,18 +114,34 @@ fun RelayStatusHeader(
                     // The single most useful thing on a screen named after the
                     // relay: where it actually is. Was nowhere on this screen.
                     if (relayAddress != null) {
-                        Text(
-                            text = relayAddress,
-                            color = SecondaryText,
-                            fontSize = 12.sp,
-                            fontFamily = FontFamily.Monospace,
+                        // The row, not the glyph run, is the tap target: a 12sp
+                        // line is ~16dp tall, a third of the 48dp minimum.
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
                             modifier = Modifier
+                                .heightIn(min = 48.dp)
                                 .clickable {
                                     clipboard.setText(AnnotatedString(relayAddress))
                                     Toast.makeText(context, "Address copied", Toast.LENGTH_SHORT).show()
                                 }
                                 .semantics { contentDescription = "Relay address: $relayAddress. Tap to copy." },
-                        )
+                        ) {
+                            Text(
+                                text = relayAddress,
+                                color = SecondaryText,
+                                fontSize = 12.sp,
+                                fontFamily = FontFamily.Monospace,
+                            )
+                            // Without a glyph, tap-to-copy is undiscoverable —
+                            // the text is styled exactly like the label above it.
+                            Icon(
+                                NostrVaultIcons.Copy,
+                                contentDescription = null,
+                                tint = SecondaryText,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
                     }
                 }
 

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/theme/Icons.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/theme/Icons.kt
@@ -68,6 +68,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material.icons.filled.Terminal
@@ -197,6 +198,7 @@ object NostrVaultIcons {
     val PlayCircle: ImageVector = Icons.Filled.PlayCircle        // play.circle.fill
     val PlayArrow: ImageVector = Icons.Filled.PlayArrow          // play.fill
     val PauseIcon: ImageVector = Icons.Filled.Pause              // pause.fill
+    val Stop: ImageVector = Icons.Filled.Stop                    // stop.fill
     val VolumeUp: ImageVector = Icons.AutoMirrored.Filled.VolumeUp   // speaker.wave.2.fill
     val VolumeOff: ImageVector = Icons.AutoMirrored.Filled.VolumeOff // speaker.slash.fill
     val PictureInPicture: ImageVector = Icons.Filled.PictureInPictureAlt // pip.enter


### PR DESCRIPTION
Closes the Android half of "relay dashboard has no Stop button and no relay address" — same shape as #9, which fixed this on macOS.

## The problem

`RelayStatusHeader.kt:28` declared `onStopRelay: () -> Unit` and never called it — threaded through two layers (`DashboardScreen.kt:2143` → `:2678` → `:2781`) and dropped at the last one. Restart was reachable as an `OutlinedButton`; Stop was already wired everywhere except the screen named after the relay (Advanced Settings, the persistent notification).

The header also never showed where the relay actually was. `config.nostrURL` is read at half a dozen other call sites in `DashboardScreen.kt` (631, 651, 1041, 1494, 1519) but never surfaced on the status header itself.

## What changed

- `RelayStatusHeader` now renders a Stop button next to Restart when `RelayStatus.RUNNING`, wired to the `onStopRelay` that was already there.
- A `relayAddress: String?` param threads from `DashboardScreen`'s `currentConfig.nostrURL` down through `DashboardSheetContent` to the header, shown under the status text.
- Tapping the address copies it via `LocalClipboardManager` and shows a Toast ("Address copied") — matching the existing copy idiom in `ComposeNoteScreen.kt` / `MediaViewerScreen.kt` rather than inventing a new one.
- Added `NostrVaultIcons.Stop` (`Icons.Filled.Stop`) next to the existing `PlayArrow`/`Pause`/`Refresh` entries.

## Verification

Built and installed the release APK on a physical device (Go native lib compiled fresh via `just android-build`), then drove it live:

- Relay Dashboard sheet shows `ONLINE` / `ws://127.0.0.1:3355` with Stop + Restart side by side.
- Tapped **Stop** — status flips to `OFFLINE`, console logs "HAVEN is shutting down (C-Shared Mode)".
- Tapped **Restart** — comes back `ONLINE`, console logs "listening at http://127.0.0.1:3355".
- Tapped the address row — Toast "Address copied", system clipboard preview shows the exact string.

`./gradlew testReleaseUnitTest` and `compileDebugKotlin` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)