### PR TITLE
feat(feed): compact rows show 3 lines and a bigger thumbnail

### DIFF
--- a/HavenApp/HavenApp/Views/FeedView.swift
+++ b/HavenApp/HavenApp/Views/FeedView.swift
@@ -2124,7 +2124,7 @@ struct FeedNoteRow: View {
                     }
                 }
 
-                // Truncated content (2 lines max)
+                // Truncated content (3 lines max)
                 let contentToShow: String = {
                     if note.kind == 6 && note.content.isEmpty, let original = rowData.resolvedOriginal {
                         return original.content
@@ -2136,7 +2136,7 @@ struct FeedNoteRow: View {
                     Text(NostrContentFormatter.resolveMentionsPlainText(contentToShow))
                         .font(.appSystem(size: 14))
                         .foregroundColor(.white)
-                        .lineLimit(2)
+                        .lineLimit(3)
                         .lineSpacing(1)
                 }
 
@@ -2175,7 +2175,7 @@ struct FeedNoteRow: View {
                         url: firstMedia,
                         isThumbnail: true
                     )
-                    .frame(width: 60, height: 60)
+                    .frame(width: 80, height: 80)
                     .aspectRatio(1, contentMode: .fill)
                     .clipShape(RoundedRectangle(cornerRadius: 6))
 

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/CompactNoteCard.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/CompactNoteCard.kt
@@ -115,7 +115,7 @@ fun CompactNoteCard(
                     )
                 }
 
-                // Body text (plain, 2 lines max). Memoize the regex-based mention
+                // Body text (plain, 3 lines max). Memoize the regex-based mention
                 // stripping so it doesn't re-run on every recomposition (e.g. each
                 // throttled profile-map update) while scrolling the compact feed.
                 if (note.content.isNotBlank()) {
@@ -127,7 +127,7 @@ fun CompactNoteCard(
                         text = plainText,
                         color = SecondaryText,
                         fontSize = 13.sp,
-                        maxLines = 2,
+                        maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
                         lineHeight = 17.sp,
                     )
@@ -141,13 +141,13 @@ fun CompactNoteCard(
                 AsyncImage(
                     model = ImageRequest.Builder(context)
                         .data(note.mediaURLs.first())
-                        .size(96) // 48dp at 2x density
+                        .size(128) // 64dp at 2x density
                         .crossfade(false) // Disable crossfade for instant rendering
                         .build(),
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
-                        .size(48.dp)
+                        .size(64.dp)
                         .clip(RoundedCornerShape(6.dp))
                         .background(TertiaryGroupedBg),
                 )


### PR DESCRIPTION
Compact View (the `rectangle.compress.vertical` toggle in the feed toolbar) gave two lines of text and a small square thumbnail. Two lines cut most notes mid-sentence, and the thumbnail was too small to tell one photo from another while scrolling.

| | Before | After |
|---|---|---|
| iOS/macOS text | `lineLimit(2)` | `lineLimit(3)` |
| iOS/macOS thumbnail | 60 × 60pt | 80 × 80pt |
| Android text | `maxLines = 2` | `maxLines = 3` |
| Android thumbnail | 48dp (`.size(96)`) | 64dp (`.size(128)`) |

Rows with short text and no media are unchanged — the third line only costs height when there is a third line. Rows with media grow by roughly 12pt, since the taller thumbnail now sets the row height.

The Android Coil request moves 96 → 128px so the bigger thumbnail is still handed a 2x source. iOS thumbnails already decode at `maxDimension = 300` (`FeedMediaView.swift:260`), which covers 80pt at 3x, so no change was needed there.

## Verification

- Rendered the compact row before/after through `ImageRenderer` at iPhone width (393pt) with four sample notes — long-with-media, short-no-media, medium-with-media, long-no-media. The narrower text column at 80pt still nets more visible text than two lines at 60pt.
- `xcodebuild -scheme HavenApp-iOS -destination 'generic/platform=iOS Simulator'` — **BUILD SUCCEEDED**.
- `./gradlew :app:compileReleaseKotlin` — clean.

Not verified on a device or against a live feed; these are layout constants, and the shapes are visible in the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
