### PR TITLE
Android: you can report and block from the feed

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/BroadcastSheet.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/BroadcastSheet.kt
@@ -96,7 +96,7 @@ fun BroadcastSheet(
 
     val note1 = remember(note.id) { HavenBridge.hexToNote1(note.id) ?: note.id }
     val nevent = remember(note.id) { HavenBridge.encodeNevent(note.id, note.pubkey, note.kind) ?: note1 }
-    val shareLink = remember(nevent) { "https://mynostrspace.com/thread/$nevent" }
+    val shareLink = remember(nevent) { threadLink(nevent) }
 
     val blastrRelays = remember {
         configStore.config.value.activeBlastrRelays.ifEmpty { DEFAULT_BLASTR_RELAYS }

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteShareLink.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteShareLink.kt
@@ -1,0 +1,14 @@
+package com.nostrvault.ui.components
+
+/**
+ * The web address a shared note points at.
+ *
+ * One definition, because there were about to be three: the broadcast sheet
+ * built this string, the feed's Copy link built it again, and the next surface
+ * that wants to share a note would have built a fourth. If the host ever
+ * changes, it changes here.
+ */
+internal const val THREAD_LINK_HOST = "https://mynostrspace.com"
+
+/** Shareable web link for a note, given its `nevent1…` (or `note1…`) reference. */
+internal fun threadLink(reference: String): String = "$THREAD_LINK_HOST/thread/$reference"

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
@@ -65,6 +65,7 @@ import com.nostrvault.ui.components.GlassPill
 import com.nostrvault.ui.components.GlassScaffold
 import com.nostrvault.ui.components.NoteCard
 import com.nostrvault.ui.components.UGCReportDialog
+import com.nostrvault.ui.components.threadLink
 import com.nostrvault.ui.components.NostrMentions
 import com.nostrvault.ui.components.ScrollCondenseEffect
 import com.nostrvault.ui.components.SkeletonFeed
@@ -644,9 +645,7 @@ fun FeedScreen(
                                     targetNote.kind,
                                 ) ?: HavenBridge.hexToNote1(targetNote.effectiveEventId)
                                 ?: targetNote.effectiveEventId
-                                clipboard.setText(
-                                    AnnotatedString("https://mynostrspace.com/thread/$nevent"),
-                                )
+                                clipboard.setText(AnnotatedString(threadLink(nevent)))
                                 Toast.makeText(context, "Link copied", Toast.LENGTH_SHORT).show()
                                 moreMenuNoteId = null
                             },

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -44,6 +46,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.compose.ui.text.style.TextOverflow
 import coil.compose.AsyncImage
+import com.nostrvault.relay.HavenBridge
 import com.nostrvault.data.model.ArticleMeta
 import com.nostrvault.data.model.FeedMode
 import com.nostrvault.data.model.FeedProfile
@@ -61,6 +64,7 @@ import com.nostrvault.ui.components.CompactNoteCard
 import com.nostrvault.ui.components.GlassPill
 import com.nostrvault.ui.components.GlassScaffold
 import com.nostrvault.ui.components.NoteCard
+import com.nostrvault.ui.components.UGCReportDialog
 import com.nostrvault.ui.components.NostrMentions
 import com.nostrvault.ui.components.ScrollCondenseEffect
 import com.nostrvault.ui.components.SkeletonFeed
@@ -117,6 +121,7 @@ fun FeedScreen(
     val parentIsNext by viewModel.parentIsNextNote.collectAsState()
     val listState = rememberLazyListState()
     val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
 
     // Inline expansion state for compact mode (iOS parity: tap expands inline first)
@@ -169,6 +174,8 @@ fun FeedScreen(
     // More menu / delete confirmation state
     var deleteNoteId by remember { mutableStateOf<String?>(null) }
     var moreMenuNoteId by remember { mutableStateOf<String?>(null) }
+    var reportNoteId by remember { mutableStateOf<String?>(null) }
+    var blockNoteId by remember { mutableStateOf<String?>(null) }
 
     // Emoji picker state
     var emojiPickerNoteId by remember { mutableStateOf<String?>(null) }
@@ -520,9 +527,12 @@ fun FeedScreen(
                                     context.startActivity(Intent.createChooser(intent, "Share Note"))
                                 },
                                 onBroadcast = { id -> broadcastNoteId = id },
-                                onMore = if (viewModel.isOwnNote(note.pubkey)) {
-                                    { id -> moreMenuNoteId = id }
-                                } else null,
+                                // Every note gets an overflow menu. Gating this on
+                                // your own notes meant other people's notes had no
+                                // menu at all, so reporting and blocking were only
+                                // reachable two navigations deep — from the note
+                                // screen, which you have to open the content to see.
+                                onMore = { id -> moreMenuNoteId = id },
                                 onLongPressLike = { id -> emojiPickerNoteId = id },
                                 modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
                             )
@@ -591,31 +601,107 @@ fun FeedScreen(
             title = { Text("Actions") },
             text = {
                 Column {
-                    // Delete (own notes only)
                     if (isOwn) {
-                        TextButton(
+                        FeedActionRow(
+                            icon = NostrVaultIcons.Delete,
+                            label = "Delete Post",
+                            tint = ErrorRed,
                             onClick = {
                                 deleteNoteId = moreMenuNoteId
                                 moreMenuNoteId = null
                             },
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth(),
-                            ) {
-                                Icon(NostrVaultIcons.Delete, contentDescription = null, tint = ErrorRed, modifier = Modifier.size(18.dp))
-                                Spacer(Modifier.width(8.dp))
-                                Text("Delete Post", color = ErrorRed)
-                            }
-                        }
+                        )
+                    } else {
+                        FeedActionRow(
+                            icon = NostrVaultIcons.Alert,
+                            label = "Report",
+                            tint = ErrorRed,
+                            onClick = {
+                                reportNoteId = moreMenuNoteId
+                                moreMenuNoteId = null
+                            },
+                        )
+                        FeedActionRow(
+                            icon = NostrVaultIcons.Blocked,
+                            label = "Block",
+                            tint = ErrorRed,
+                            onClick = {
+                                blockNoteId = moreMenuNoteId
+                                moreMenuNoteId = null
+                            },
+                        )
+                    }
+                    // Copy link is offered for any note, yours included.
+                    if (targetNote != null) {
+                        FeedActionRow(
+                            icon = NostrVaultIcons.Share,
+                            label = "Copy link",
+                            tint = PrimaryText,
+                            onClick = {
+                                val nevent = HavenBridge.encodeNevent(
+                                    targetNote.effectiveEventId,
+                                    targetNote.pubkey,
+                                    targetNote.kind,
+                                ) ?: HavenBridge.hexToNote1(targetNote.effectiveEventId)
+                                ?: targetNote.effectiveEventId
+                                clipboard.setText(
+                                    AnnotatedString("https://mynostrspace.com/thread/$nevent"),
+                                )
+                                Toast.makeText(context, "Link copied", Toast.LENGTH_SHORT).show()
+                                moreMenuNoteId = null
+                            },
+                        )
                     }
                 }
             },
-            confirmButton = {
+            // Cancel is the dismiss action, so it belongs in the dismiss slot.
+            // In `confirmButton` it took the emphasised position, which reads as
+            // "this is the thing to do" on a menu whose real items are
+            // destructive.
+            confirmButton = {},
+            dismissButton = {
                 TextButton(onClick = { moreMenuNoteId = null }) {
                     Text("Cancel")
                 }
+            },
+        )
+    }
+
+    // Report dialog (NIP-56 reason picker). Reporting also blocks the author,
+    // matching NoteDetailScreen and iOS.
+    val reportTarget = reportNoteId?.let { id -> notes.find { it.id == id || it.effectiveEventId == id } }
+    if (reportTarget != null) {
+        UGCReportDialog(
+            onReport = { reason, description ->
+                viewModel.reportNote(
+                    reportTarget.effectiveEventId,
+                    reportTarget.pubkey,
+                    reason,
+                    description,
+                )
+                reportNoteId = null
+            },
+            onDismiss = { reportNoteId = null },
+        )
+    }
+
+    // Block confirmation
+    val blockTarget = blockNoteId?.let { id -> notes.find { it.id == id || it.effectiveEventId == id } }
+    if (blockTarget != null) {
+        AlertDialog(
+            onDismissRequest = { blockNoteId = null },
+            title = { Text("Block User") },
+            text = { Text("Block this user? Their posts will be hidden from your feed.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.blockUser(blockTarget.pubkey)
+                        blockNoteId = null
+                    },
+                ) { Text("Block", color = ErrorRed) }
+            },
+            dismissButton = {
+                TextButton(onClick = { blockNoteId = null }) { Text("Cancel") }
             },
         )
     }
@@ -1350,4 +1436,30 @@ private fun List<String>.resolveAgainst(
     val resolved = HashMap<String, FeedProfile>(size)
     for (pubkey in this) profiles[pubkey]?.let { resolved[pubkey] = it }
     return resolved
+}
+
+/**
+ * One row of the feed's Actions dialog.
+ *
+ * Extracted because the dialog now has four of these and they were being
+ * hand-assembled — icon, spacer, coloured label — which is exactly how the
+ * variants drift apart.
+ */
+@Composable
+private fun FeedActionRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    tint: androidx.compose.ui.graphics.Color,
+    onClick: () -> Unit,
+) {
+    TextButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(8.dp))
+            Text(label, color = tint)
+        }
+    }
 }

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedViewModel.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedViewModel.kt
@@ -306,6 +306,26 @@ class FeedViewModel @Inject constructor(
         return pubkey == nostrService.activeHexPubkey
     }
 
+    // ── Moderation ─────────────────────────────────────────────
+    //
+    // Same paths NoteDetailScreen already uses. Blocking writes the npub to
+    // `blockedNpubs`, publishes the mute list, and drops the author's notes from
+    // the in-memory feed — which is why the feed visibly loses them without a
+    // reload. Block and mute are one action in this app; the menu says "Block"
+    // once rather than offering two labels for the same event.
+
+    fun blockUser(pubkey: String) {
+        viewModelScope.launch { feedService.blockUser(pubkey) }
+    }
+
+    /** NIP-56 report. Also blocks the author, matching NoteDetail and iOS. */
+    fun reportNote(noteId: String, pubkey: String, reason: String, description: String = "") {
+        viewModelScope.launch {
+            nostrService.reportEvent(noteId, pubkey, reason, description.ifBlank { null })
+            feedService.blockUser(pubkey)
+        }
+    }
+
     // Exposed for BroadcastSheet which needs direct service access
     val feedServiceRef: FeedService get() = feedService
     val nostrServiceRef: NostrService get() = nostrService


### PR DESCRIPTION
Closes the `Android: you cannot report or block from the feed` issue.

## The defect

`FeedScreen.kt:523-525` handed `NoteCard` an `onMore` handler **only for your own notes**:

```kotlin
onMore = if (viewModel.isOwnNote(note.pubkey)) {
    { id -> moreMenuNoteId = id }
} else null,
```

`NoteCard.kt:262` draws the overflow button only when `onMore` is non-null. So other people's notes had no overflow menu at all, and the single item in the menu when it did appear was "Delete Post".

Reporting required: see the content → tap into the note → find the overflow → Report. Two navigations deep from the only screen where the content appears, and it is the path a user takes immediately after being shown something they did not want to see.

## What this does

Every note gets the menu.

| Note | Items |
|---|---|
| Yours | Delete Post, Copy link |
| Anyone else's | Report, Block, Copy link |

This is wiring, not new capability — `FeedService.blockUser` (`:1583`) and `UGCReportDialog` already existed, and these are the same paths `NoteDetailScreen` uses. Report also blocks the author, matching NoteDetail and iOS.

**On "Mute":** the issue asks for Report / Block / Mute / Copy link. Block *is* mute in this app — `blockUser` writes the npub to `blockedNpubs` and publishes the mute list. Offering two labels for one signed event would be a worse menu, so it says "Block" once. Flagging it because it is a deliberate departure from the issue text.

## Also fixed

Cancel moves out of the dialog's `confirmButton` slot into `dismissButton`. It had the emphasised position on a menu whose real items are destructive.

The four hand-assembled icon/spacer/label rows became one `FeedActionRow`, since four copies is how variants drift apart.

## Still open after this

`onMore` has exactly one call site in the app. Profile, Search and NoteDetail's `NoteCard`s don't pass it at all, so a stranger's note in **search results** still has no overflow menu. Profile has its own Block at `ProfileScreen.kt:193`; search has nothing. Out of scope for this issue, worth its own.

## Verification

- `:app:compileDebugKotlin` clean.
- **Not yet verified on a device** — no Android device attached to this Mac right now. The issue's verify step is the right one and I have not run it: from the feed, report and block a note you did not write, and confirm the author disappears without reopening the app. `blockUser` does filter `_notes` and recompute, so it should; that is a prediction, not a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)