### PR TITLE
Android: the Drafts screen is the drafts screen

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/navigation/NavGraph.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/navigation/NavGraph.kt
@@ -380,9 +380,18 @@ fun NostrVaultNavHost(
                 ComposeNoteScreen(
                     onPublished = { navController.popBackStack() },
                     onBack = { navController.popBackStack() },
-                    onResumeDraft = { draftId, replyToId, quoteToId ->
-                        // Replace the current composer with one bound to the chosen draft
-                        // (matches iOS, which loads the draft into the open composer).
+                    onOpenDrafts = { navController.navigate(Screen.Drafts.route) },
+                )
+            }
+
+            composable(Screen.Drafts.route) {
+                DraftsScreen(
+                    onResumeDraft = { draftId, _, replyToId, quoteToId ->
+                        // Replace the composer this was opened from, rather than
+                        // stacking a second one behind it (matches iOS, which loads
+                        // the draft into the open composer). Popping Drafts as well
+                        // means Back from the resumed draft leaves the composer
+                        // entirely instead of landing on the list again.
                         navController.navigate(
                             Screen.ComposeNote.createRoute(
                                 replyToNoteId = replyToId,
@@ -392,20 +401,6 @@ fun NostrVaultNavHost(
                         ) {
                             popUpTo(Screen.ComposeNote.route) { inclusive = true }
                         }
-                    },
-                )
-            }
-
-            composable(Screen.Drafts.route) {
-                DraftsScreen(
-                    onResumeDraft = { draftId, _, replyToId, quoteToId ->
-                        navController.navigate(
-                            Screen.ComposeNote.createRoute(
-                                replyToNoteId = replyToId,
-                                quoteToNoteId = quoteToId,
-                                draftId = draftId,
-                            )
-                        )
                     },
                     onBack = { navController.popBackStack() },
                 )

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/ComposeNoteScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/ComposeNoteScreen.kt
@@ -205,7 +205,6 @@ class ComposeNoteViewModel @Inject constructor(
     /** All saved drafts for the active account, backing the in-composer picker. */
     val drafts: StateFlow<List<Draft>> = draftService.drafts
 
-    fun deleteDraft(id: String) = draftService.deleteDraft(id)
 
     init {
         // Start waking sleeping mirror hosts (e.g. the Mac relay) now, so
@@ -880,7 +879,7 @@ fun ComposeNoteScreen(
     replyToNoteId: String? = null,
     onPublished: () -> Unit,
     onBack: () -> Unit,
-    onResumeDraft: (draftId: String, replyToId: String?, quoteToId: String?) -> Unit = { _, _, _ -> },
+    onOpenDrafts: () -> Unit = {},
     viewModel: ComposeNoteViewModel = hiltViewModel(),
 ) {
     val content by viewModel.content.collectAsState()
@@ -898,7 +897,6 @@ fun ComposeNoteScreen(
     val accounts by viewModel.accounts.collectAsState()
     val activeAccount by viewModel.activeAccount.collectAsState()
     var showAccountSwitcher by remember { mutableStateOf(false) }
-    var showDraftPicker by remember { mutableStateOf(false) }
     val colors = LocalNostrVaultColors.current
     val context = LocalContext.current
 
@@ -951,7 +949,7 @@ fun ComposeNoteScreen(
                     // compose when drafts exist, not while editing an existing draft.
                     if (drafts.isNotEmpty() && !viewModel.isEditingExistingDraft) {
                         Surface(
-                            onClick = { showDraftPicker = true },
+                            onClick = onOpenDrafts,
                             shape = CircleShape,
                             color = colors.primary.copy(alpha = 0.12f),
                             contentColor = colors.primary,
@@ -1264,130 +1262,6 @@ fun ComposeNoteScreen(
             },
             onDismiss = { showAccountSwitcher = false },
         )
-    }
-
-    // In-composer draft picker (mirrors iOS DraftPickerView)
-    if (showDraftPicker) {
-        DraftPickerSheet(
-            drafts = drafts,
-            onSelect = { draft ->
-                showDraftPicker = false
-                onResumeDraft(draft.id, draft.replyToId, draft.quoteId)
-            },
-            onDelete = { draft -> viewModel.deleteDraft(draft.id) },
-            onDismiss = { showDraftPicker = false },
-        )
-    }
-}
-
-/** Bottom-sheet list of saved drafts shown from the composer; mirrors iOS DraftPickerView. */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
-@Composable
-private fun DraftPickerSheet(
-    drafts: List<Draft>,
-    onSelect: (Draft) -> Unit,
-    onDelete: (Draft) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val colors = LocalNostrVaultColors.current
-    val dateFormatter = remember { SimpleDateFormat("MMM d, h:mm a", Locale.getDefault()) }
-
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        containerColor = WindowBackground,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 16.dp),
-        ) {
-            Text(
-                text = "Drafts",
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold,
-                color = PrimaryText,
-                modifier = Modifier.padding(bottom = 12.dp),
-            )
-
-            if (drafts.isEmpty()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(160.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(text = "No drafts", color = SecondaryText, fontSize = 14.sp)
-                }
-            } else {
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.heightIn(max = 420.dp),
-                ) {
-                    items(items = drafts, key = { it.id }) { draft ->
-                        Surface(
-                            shape = RoundedCornerShape(12.dp),
-                            color = SecondaryGroupedBg,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onSelect(draft) },
-                        ) {
-                            Column(modifier = Modifier.padding(14.dp)) {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
-                                    val typeLabel = when {
-                                        draft.isReply -> "Reply"
-                                        draft.isQuote -> "Quote"
-                                        else -> null
-                                    }
-                                    if (typeLabel != null) {
-                                        Surface(
-                                            shape = RoundedCornerShape(6.dp),
-                                            color = colors.primary.copy(alpha = 0.15f),
-                                        ) {
-                                            Text(
-                                                text = typeLabel,
-                                                color = colors.primary,
-                                                fontSize = 11.sp,
-                                                fontWeight = FontWeight.SemiBold,
-                                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-                                            )
-                                        }
-                                    }
-                                    Spacer(Modifier.weight(1f))
-                                    Text(
-                                        text = dateFormatter.format(Date(draft.updatedAt)),
-                                        color = TertiaryText,
-                                        fontSize = 12.sp,
-                                    )
-                                    IconButton(
-                                        onClick = { onDelete(draft) },
-                                        modifier = Modifier.size(28.dp),
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Delete,
-                                            contentDescription = "Delete draft",
-                                            tint = ErrorRed,
-                                            modifier = Modifier.size(18.dp),
-                                        )
-                                    }
-                                }
-                                Spacer(Modifier.height(8.dp))
-                                Text(
-                                    text = draft.preview.ifEmpty { "(empty draft)" },
-                                    color = PrimaryText,
-                                    fontSize = 15.sp,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/ComposeNoteScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/ComposeNoteScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -84,10 +83,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.security.MessageDigest
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 /**


### PR DESCRIPTION
Closes the `Android: the Drafts screen is registered and unreachable` issue — and corrects its premise.

## What the issue said

`DraftsScreen.kt` is 382 lines, `Screen.Drafts` is registered at `NavGraph.kt:399`, and nothing anywhere calls `navigate(Screen.Drafts…)`. All true, and the scan behind it was sound.

## What was actually happening

Saved drafts were **not** unreachable. The composer's toolbar badge (`ComposeNoteScreen.kt:952`) opened `DraftPickerSheet` — a second, lesser copy of the same feature, living in the same file. Drafts were reachable; the good screen was not.

That is a different defect with a different fix. Adding a second entry point, as the issue suggests, would have left two drafts surfaces in the app.

## Which one is real

iOS settles it. There is exactly one drafts surface — `HavenApp/Views/DraftPickerView.swift`, 204 lines, presented from `ComposeView.swift:327` and nowhere else — and it carries the multi-select, Select All, and bulk delete.

`DraftsScreen` is that port. `DraftPickerSheet` is the duplicate that got wired instead.

## What this does

- The composer badge opens `DraftsScreen`.
- `DraftPickerSheet` is deleted, along with `ComposeNoteViewModel.deleteDraft`, which existed only to serve it.
- Selecting a draft replaces the composer it was opened from **and** pops the list, so Back from a resumed draft leaves the composer rather than landing on the list again.

Net **−125 lines**. One surface, matching iOS.

## It also closes a defect from another issue

The `media cropping, feed layout shift, and unconfirmed draft delete` issue's third defect is `ComposeNoteScreen.kt:1365-1375` — a trash icon in the draft picker that calls `onDelete(draft)` immediately, unrecoverably, one tap, right beside the row you tap to open the draft.

That icon went with the sheet. `DraftsScreen` deletes by swipe, or by selection with a count-aware confirmation ("Delete 3 drafts?").

The issue also asks to check `DraftsScreen.kt:223` for the same problem. I did: it is swipe-to-delete, unconfirmed — and that is deliberate and matches iOS (`DraftPickerView.swift:116`, "Swipe-to-delete stays available outside selection"). A swipe is a committed gesture, not a mis-tap next to the thing you meant to open. Leaving it.

## Verification

- `:app:compileDebugKotlin` clean.
- **Not verified on a device** — no Android device attached to this Mac right now. What needs walking when one is: save a draft, leave compose, tap the badge, resume it, and press Back — the nav stack change is the part worth watching, and a compile cannot see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)