### PR TITLE
fix(macos): real image pager instead of blank tab strip

### DIFF
--- a/HavenApp/HavenApp.xcodeproj/project.pbxproj
+++ b/HavenApp/HavenApp.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		9EBACE9543A3F1BC4C3C054D /* SwiftNIP46Handshake.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2003F8C6D98618A746D1E7 /* SwiftNIP46Handshake.swift */; };
 		A2466D5E5282712286740FE2 /* DraftService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3800D9290BD369F4F26BC5C3 /* DraftService.swift */; };
 		A36D3F7A908A749F7B34206D /* LiveChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A21B9BEF9DAADA51C5B8C4D3 /* LiveChat.swift */; };
+		A42CB5C975C2F3ADAE17DC9B /* MediaPagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECDB003F4997CEABAC3644 /* MediaPagerView.swift */; };
 		A48F920B274A38D5BD818EBB /* SilentPaymentsKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34D407BB5082F01DD1EA2C1D /* SilentPaymentsKit */; };
 		A4CC418BB19F41A7C051EF00 /* EngagementTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01EFA5F14E595113B47E8FC2 /* EngagementTracker.swift */; };
 		A5B06D91684942B06596203F /* QuickActionsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0A09BAA2ED410A3EAD8AB /* QuickActionsWidget.swift */; };
@@ -284,6 +285,7 @@
 		B2889A6B902C69E8612485A8 /* CustomZapSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFC29BEE8A95187513A3787 /* CustomZapSheet.swift */; };
 		B2D799D053929F4DB6071E97 /* PowPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9953E9DA772C31A74141B335 /* PowPreferences.swift */; };
 		B3A065D965688DBC83174179 /* FeedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC33568A91E5B5B737A03D1F /* FeedService.swift */; };
+		B65312DC3E3DC12BEA80B9DA /* MediaPagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ECDB003F4997CEABAC3644 /* MediaPagerView.swift */; };
 		B764BF0A8BA3B90BCBD9B52E /* Chime.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = D5F84F499115E83DCA24A989 /* Chime.mp3 */; };
 		B812DD60EB0D5F8D72E69A0C /* IconFilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E31B27EC2F18B0F61C3A10A /* IconFilterButton.swift */; };
 		B90CCC03D296B8EDD6E7AC90 /* FollowingBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B813614AC332D9C184C78 /* FollowingBackupService.swift */; };
@@ -565,6 +567,7 @@
 		93ED6BB091A4EBC9250A7858 /* Theming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theming.swift; sourceTree = "<group>"; };
 		9410075B1BE7FC5BBAA601AD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95DDFCB3C82896EDE259BF03 /* NVWidgetBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NVWidgetBridge.swift; sourceTree = "<group>"; };
+		95ECDB003F4997CEABAC3644 /* MediaPagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPagerView.swift; sourceTree = "<group>"; };
 		982E5846CE3EB2461F41A4FB /* VaultChangeHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultChangeHandlers.swift; sourceTree = "<group>"; };
 		9953E9DA772C31A74141B335 /* PowPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowPreferences.swift; sourceTree = "<group>"; };
 		998E2BF3A6A7EE811FD18ED7 /* RecipeFeedViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeFeedViews.swift; sourceTree = "<group>"; };
@@ -705,6 +708,7 @@
 				70CE0E2EC47B06E218FF6548 /* LogsView.swift */,
 				B9C768286B9966515F364889 /* MediaGallery */,
 				1EA2FCD67EDBE04915305C51 /* MediaGalleryTypes.swift */,
+				95ECDB003F4997CEABAC3644 /* MediaPagerView.swift */,
 				3479233DA13D1E79374B68FD /* MediaTabView.swift */,
 				7D08ABA7CDBFD26CF0423E33 /* MediaTypeDetector.swift */,
 				325A99A7D646C515AB620EE5 /* MenuBarStatusView.swift */,
@@ -1357,6 +1361,7 @@
 				5FDB457BFF6A6A03969C299B /* MediaGridItem.swift in Sources */,
 				2F1FD7253CE6BB1663ADC269 /* MediaItem.swift in Sources */,
 				E6B954A06F5DEC06F4C960AE /* MediaListItem.swift in Sources */,
+				A42CB5C975C2F3ADAE17DC9B /* MediaPagerView.swift in Sources */,
 				82226E9D704A71764A35BB7D /* MediaTabView.swift in Sources */,
 				1F0E85CA638E913E0179BA1D /* MediaTypeDetector.swift in Sources */,
 				7682D9DBB00E467214FB1150 /* MempoolAPIService.swift in Sources */,
@@ -1569,6 +1574,7 @@
 				11CA2627A013602A67310A7D /* MediaGridItem.swift in Sources */,
 				C8F9F8DCF05C8D05CBFD37F2 /* MediaItem.swift in Sources */,
 				9A441353279669903E59CBD0 /* MediaListItem.swift in Sources */,
+				B65312DC3E3DC12BEA80B9DA /* MediaPagerView.swift in Sources */,
 				68F697D47223F3BB082DC65B /* MediaTabView.swift in Sources */,
 				8C6C5418A73D68D54599A473 /* MediaTypeDetector.swift in Sources */,
 				F10135C9F1B704EF4CFDCDB7 /* MempoolAPIService.swift in Sources */,

--- a/HavenApp/HavenApp/Views/FeedView.swift
+++ b/HavenApp/HavenApp/Views/FeedView.swift
@@ -779,16 +779,12 @@ struct FeedView: View {
                     .opacity(max(0.1, 1.0 - (abs(galleryDragOffset.height) / 500.0)))
                     .ignoresSafeArea()
                 
-                TabView(selection: $selectedGridMediaNoteId) {
-                    ForEach(gridMediaSnapshot) { note in
-                        if let firstMediaURL = note.mediaURLs.first {
-                            FeedMediaViewer(url: firstMediaURL, enableDragDismiss: false, onDismiss: { isShowingGridMediaViewer = false })
-                                .tag(note.id as String?)
-                                .transition(.opacity.animation(Motion.media))
-                        }
+                MediaPagerView(items: gridMediaSnapshot.map { $0.id }, selection: $selectedGridMediaNoteId) { noteId in
+                    if let note = gridMediaSnapshot.first(where: { $0.id == noteId }), let firstMediaURL = note.mediaURLs.first {
+                        FeedMediaViewer(url: firstMediaURL, enableDragDismiss: false, onDismiss: { isShowingGridMediaViewer = false })
+                            .transition(.opacity.animation(Motion.media))
                     }
                 }
-                .mediaTabViewStyleCompat()
                 .animation(Motion.pick, value: selectedGridMediaNoteId)
                 .offset(y: galleryDragOffset.height)
                 .scaleEffect(max(0.8, 1.0 - (abs(galleryDragOffset.height) / 1000.0)))
@@ -2979,20 +2975,17 @@ struct FeedNoteRow: View {
             .frame(maxWidth: .infinity)
         } else {
             // Multiple media — quick snappy fade carousel
-            TabView {
-                ForEach(urls, id: \.absoluteString) { url in
-                    FeedMediaView(
-                        url: url,
-                        onTap: { onMedia?(url, urls) },
-                        maxHeight: 400,
-                        isThumbnail: false
-                    )
-                    .frame(maxWidth: .infinity)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .transition(.opacity.animation(Motion.media))
-                }
+            MediaPagerView(items: urls) { url in
+                FeedMediaView(
+                    url: url,
+                    onTap: { onMedia?(url, urls) },
+                    maxHeight: 400,
+                    isThumbnail: false
+                )
+                .frame(maxWidth: .infinity)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .transition(.opacity.animation(Motion.media))
             }
-            .mediaTabViewStyleCompat()
             .frame(height: 400)
             // Add a subtle border or background if desired to distinguish bounds
             // But FeedMediaView already has clipShape and overlay

--- a/HavenApp/HavenApp/Views/FeedView.swift
+++ b/HavenApp/HavenApp/Views/FeedView.swift
@@ -779,13 +779,14 @@ struct FeedView: View {
                     .opacity(max(0.1, 1.0 - (abs(galleryDragOffset.height) / 500.0)))
                     .ignoresSafeArea()
                 
-                MediaPagerView(items: gridMediaSnapshot.map { $0.id }, selection: $selectedGridMediaNoteId) { noteId in
+                MediaPagerView(items: gridMediaSnapshot.map { $0.id }, selection: $selectedGridMediaNoteId, enableKeyboardNavigation: true) { noteId in
                     if let note = gridMediaSnapshot.first(where: { $0.id == noteId }), let firstMediaURL = note.mediaURLs.first {
                         FeedMediaViewer(url: firstMediaURL, enableDragDismiss: false, onDismiss: { isShowingGridMediaViewer = false })
+                            #if os(iOS)
                             .transition(.opacity.animation(Motion.media))
+                            #endif
                     }
                 }
-                .animation(Motion.pick, value: selectedGridMediaNoteId)
                 .offset(y: galleryDragOffset.height)
                 .scaleEffect(max(0.8, 1.0 - (abs(galleryDragOffset.height) / 1000.0)))
                 .gesture(
@@ -2984,7 +2985,9 @@ struct FeedNoteRow: View {
                 )
                 .frame(maxWidth: .infinity)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                #if os(iOS)
                 .transition(.opacity.animation(Motion.media))
+                #endif
             }
             .frame(height: 400)
             // Add a subtle border or background if desired to distinguish bounds

--- a/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryViewer.swift
+++ b/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryViewer.swift
@@ -231,11 +231,12 @@ extension MediaGalleryView {
 
                 Spacer()
 
-                MediaPagerView(items: displayMedia, selection: $selectedMedia) { mediaItem in
+                MediaPagerView(items: displayMedia, selection: $selectedMedia, enableKeyboardNavigation: true) { mediaItem in
                     MediaItemRenderer(mediaItem: mediaItem)
+                        #if os(iOS)
                         .transition(.opacity.animation(Motion.media))
+                        #endif
                 }
-                .animation(Motion.pick, value: selectedMedia?.id)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .offset(y: dragOffset.height)
                 .scaleEffect(max(0.8, 1.0 - (abs(dragOffset.height) / 1000.0)))

--- a/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryViewer.swift
+++ b/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryViewer.swift
@@ -231,14 +231,10 @@ extension MediaGalleryView {
 
                 Spacer()
 
-                TabView(selection: $selectedMedia) {
-                    ForEach(displayMedia) { mediaItem in
-                        MediaItemRenderer(mediaItem: mediaItem)
-                            .tag(mediaItem as MediaItem?)
-                            .transition(.opacity.animation(Motion.media))
-                    }
+                MediaPagerView(items: displayMedia, selection: $selectedMedia) { mediaItem in
+                    MediaItemRenderer(mediaItem: mediaItem)
+                        .transition(.opacity.animation(Motion.media))
                 }
-                .mediaTabViewStyleCompat()
                 .animation(Motion.pick, value: selectedMedia?.id)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .offset(y: dragOffset.height)

--- a/HavenApp/HavenApp/Views/MediaPagerView.swift
+++ b/HavenApp/HavenApp/Views/MediaPagerView.swift
@@ -11,12 +11,33 @@ struct MediaPagerView<Item: Hashable, ItemContent: View>: View {
     let items: [Item]
     let content: (Item) -> ItemContent
 
+    /// Opts into `.focusable()` + left/right arrow-key navigation. Only the full-screen,
+    /// one-note-at-a-time viewers (profile media viewer, media gallery viewer, the feed's
+    /// grid media viewer) set this to `true`. Inline carousels embedded in scrolling rows
+    /// (feed rows, vault rows, reposted notes) always call `MediaPagerView` with more than
+    /// one item already — gating on `items.count > 1` alone wouldn't stop every media row
+    /// in a list from becoming a silent keyboard tab stop, so those call sites simply leave
+    /// this off and rely on the always-visible tap-target arrow buttons instead.
+    var enableKeyboardNavigation: Bool = false
+
     private let externalSelection: Binding<Item?>?
     @State private var localSelection: Item?
 
-    init(items: [Item], selection: Binding<Item?>? = nil, @ViewBuilder content: @escaping (Item) -> ItemContent) {
+    /// Index-based identity for the current page. `selection` (an `Item`) is still exposed
+    /// to callers for compatibility with existing bindings, but paging itself is driven off
+    /// this index so two pages sharing the same value (a note repeating the same image URL)
+    /// can't collide the way a `firstIndex(of:)` value lookup would.
+    @State private var index: Int?
+
+    init(
+        items: [Item],
+        selection: Binding<Item?>? = nil,
+        enableKeyboardNavigation: Bool = false,
+        @ViewBuilder content: @escaping (Item) -> ItemContent
+    ) {
         self.items = items
         self.externalSelection = selection
+        self.enableKeyboardNavigation = enableKeyboardNavigation
         self.content = content
         if selection == nil {
             self._localSelection = State(initialValue: items.first)
@@ -30,18 +51,68 @@ struct MediaPagerView<Item: Hashable, ItemContent: View>: View {
         )
     }
 
+    /// The index used to drive paging on both platforms. Writing to it also writes the
+    /// corresponding item into `selectionBinding`, keeping the external `Item?` contract in
+    /// sync without ever routing an internal step through a value-based lookup.
+    private var indexBinding: Binding<Int?> {
+        Binding(
+            get: { index },
+            set: { newIndex in
+                index = newIndex
+                if let newIndex, items.indices.contains(newIndex) {
+                    selectionBinding.wrappedValue = items[newIndex]
+                }
+            }
+        )
+    }
+
     var body: some View {
+        pagerBody
+            .accessibilityValue(items.isEmpty ? "" : "Image \((index ?? 0) + 1) of \(items.count)")
+            .onAppear { syncIndexOnAppear() }
+            .onChange(of: items) { _, newItems in reconcile(after: newItems) }
+    }
+
+    @ViewBuilder
+    private var pagerBody: some View {
         #if os(iOS)
-        TabView(selection: selectionBinding) {
-            ForEach(items, id: \.self) { item in
-                content(item).tag(item as Item?)
+        TabView(selection: indexBinding) {
+            ForEach(Array(items.enumerated()), id: \.offset) { offset, item in
+                content(item).tag(offset as Int?)
             }
         }
         // Dots hidden so the viewer stays clean; callers show their own position UI where needed.
         .tabViewStyle(.page(indexDisplayMode: .never))
         #else
-        MacMediaPager(items: items, selection: selectionBinding, content: content)
+        MacMediaPager(items: items, index: indexBinding, enableKeyboardNavigation: enableKeyboardNavigation, content: content)
         #endif
+    }
+
+    private func syncIndexOnAppear() {
+        guard index == nil else { return }
+        if let sel = selectionBinding.wrappedValue, let found = items.firstIndex(of: sel) {
+            index = found
+        } else if !items.isEmpty {
+            index = 0
+            selectionBinding.wrappedValue = items[0]
+        }
+    }
+
+    /// Called when `items` changes under a stable view identity. Keeps the current selection
+    /// if it's still present at the same index; otherwise re-resolves it (or falls back to
+    /// the first item, or to nothing if `items` is now empty) rather than letting `selection`
+    /// or `index` point past the end of the array.
+    private func reconcile(after newItems: [Item]) {
+        let currentlySelected = selectionBinding.wrappedValue
+        if let idx = index, newItems.indices.contains(idx), let currentlySelected, newItems[idx] == currentlySelected {
+            return
+        }
+        if let currentlySelected, let found = newItems.firstIndex(of: currentlySelected) {
+            index = found
+            return
+        }
+        index = newItems.isEmpty ? nil : 0
+        selectionBinding.wrappedValue = newItems.first
     }
 }
 
@@ -50,35 +121,42 @@ struct MediaPagerView<Item: Hashable, ItemContent: View>: View {
 /// rather than appearing only on hover.
 private struct MacMediaPager<Item: Hashable, ItemContent: View>: View {
     let items: [Item]
-    @Binding var selection: Item?
+    @Binding var index: Int?
+    let enableKeyboardNavigation: Bool
     let content: (Item) -> ItemContent
 
-    private var currentIndex: Int? {
-        guard let selection else { return nil }
-        return items.firstIndex(of: selection)
+    var body: some View {
+        if enableKeyboardNavigation && items.count > 1 {
+            pagerStack
+                .focusable()
+                .onKeyPress(.leftArrow) { step(-1) ? .handled : .ignored }
+                .onKeyPress(.rightArrow) { step(1) ? .handled : .ignored }
+        } else {
+            pagerStack
+        }
     }
 
-    var body: some View {
+    private var pagerStack: some View {
         ZStack {
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 0) {
-                    ForEach(items, id: \.self) { item in
+                    ForEach(Array(items.enumerated()), id: \.offset) { offset, item in
                         content(item)
                             .containerRelativeFrame(.horizontal)
-                            .id(item)
+                            .id(offset)
                     }
                 }
                 .scrollTargetLayout()
             }
             .scrollTargetBehavior(.paging)
-            .scrollPosition(id: $selection)
+            .scrollPosition(id: $index)
             .scrollDisabled(items.count <= 1)
 
             if items.count > 1 {
                 HStack {
-                    pagerArrow(systemName: "chevron.left", enabled: (currentIndex ?? 0) > 0) { step(-1) }
+                    pagerArrow(systemName: "chevron.left", accessibilityLabel: "Previous image", enabled: (index ?? 0) > 0) { _ = step(-1) }
                     Spacer()
-                    pagerArrow(systemName: "chevron.right", enabled: (currentIndex ?? 0) < items.count - 1) { step(1) }
+                    pagerArrow(systemName: "chevron.right", accessibilityLabel: "Next image", enabled: (index ?? 0) < items.count - 1) { _ = step(1) }
                 }
                 .padding(.horizontal, 12)
                 .allowsHitTesting(true)
@@ -91,52 +169,61 @@ private struct MacMediaPager<Item: Hashable, ItemContent: View>: View {
                 .allowsHitTesting(false)
             }
         }
-        .focusable()
-        .onKeyPress(.leftArrow) { step(-1); return .handled }
-        .onKeyPress(.rightArrow) { step(1); return .handled }
-        .onAppear {
-            if selection == nil { selection = items.first }
-        }
     }
 
-    private func step(_ delta: Int) {
-        guard let idx = currentIndex else {
-            selection = items.first
-            return
+    /// Moves the current page by `delta`. Returns whether the page actually moved, so key
+    /// handlers can report `.ignored` at the ends and let the event propagate to the
+    /// enclosing scroll view / list instead of swallowing it.
+    @discardableResult
+    private func step(_ delta: Int) -> Bool {
+        guard let idx = index else {
+            guard !items.isEmpty else { return false }
+            index = 0
+            return true
         }
         let next = idx + delta
-        guard items.indices.contains(next) else { return }
-        withAnimation(Motion.pick) { selection = items[next] }
+        guard items.indices.contains(next) else { return false }
+        withAnimation(Motion.pick) { index = next }
+        return true
     }
 
-    private func pagerArrow(systemName: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+    private func pagerArrow(systemName: String, accessibilityLabel: String, enabled: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundColor(.white)
                 .frame(width: 28, height: 28)
-                .background(Circle().fill(Color.black.opacity(0.45)))
+                // 0.7 opacity black over a worst-case bright (L≈0.9) image composites to an
+                // effective background luminance of 0.9*(1-0.7) = 0.27; against a white
+                // (L=1.0) glyph that's (1.0+0.05)/(0.27+0.05) ≈ 3.3:1, clearing the 3:1
+                // WCAG non-text contrast minimum. The old 0.45 opacity only reached ~1.9:1.
+                .background(Circle().fill(Color.black.opacity(0.7)))
                 .overlay(Circle().stroke(Color.borderHairline, lineWidth: 0.5))
         }
         .buttonStyle(.plain)
         .opacity(enabled ? 1 : 0.35)
         .disabled(!enabled)
         .animation(Motion.chrome, value: enabled)
+        .accessibilityLabel(accessibilityLabel)
     }
 
     private var pageDots: some View {
         HStack(spacing: 6) {
             ForEach(items.indices, id: \.self) { i in
-                let isCurrent = i == (currentIndex ?? 0)
+                let isCurrent = i == (index ?? 0)
                 Circle()
-                    .fill(isCurrent ? Color.white : Color.white.opacity(0.35))
+                    .fill(isCurrent ? Color.white : Color.white.opacity(0.55))
+                    // A hairline stroke keeps inactive dots readable as a distinct state
+                    // even when the fill alone would wash out over a bright photo.
+                    .overlay(Circle().stroke(Color.white.opacity(isCurrent ? 0 : 0.9), lineWidth: 0.5))
                     .frame(width: isCurrent ? 6 : 5, height: isCurrent ? 6 : 5)
+                    .accessibilityHidden(true)
             }
         }
-        .animation(Motion.pick, value: currentIndex)
+        .animation(Motion.pick, value: index)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(Capsule().fill(Color.black.opacity(0.45)))
+        .background(Capsule().fill(Color.black.opacity(0.7)))
     }
 }
 #endif

--- a/HavenApp/HavenApp/Views/MediaPagerView.swift
+++ b/HavenApp/HavenApp/Views/MediaPagerView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Cross-platform image/media pager.
+///
+/// `TabView(selection:)` with `.page` style doesn't exist on macOS (Apple never shipped
+/// it there), and macOS's default `.automatic` TabViewStyle draws an unlabelled tab strip
+/// instead of a pager — there's no public way to restyle or suppress that chrome from
+/// outside the view that builds it, so this owns the platform split itself rather than
+/// being a modifier bolted onto someone else's `TabView`.
+struct MediaPagerView<Item: Hashable, ItemContent: View>: View {
+    let items: [Item]
+    let content: (Item) -> ItemContent
+
+    private let externalSelection: Binding<Item?>?
+    @State private var localSelection: Item?
+
+    init(items: [Item], selection: Binding<Item?>? = nil, @ViewBuilder content: @escaping (Item) -> ItemContent) {
+        self.items = items
+        self.externalSelection = selection
+        self.content = content
+        if selection == nil {
+            self._localSelection = State(initialValue: items.first)
+        }
+    }
+
+    private var selectionBinding: Binding<Item?> {
+        externalSelection ?? Binding(
+            get: { localSelection },
+            set: { localSelection = $0 }
+        )
+    }
+
+    var body: some View {
+        #if os(iOS)
+        TabView(selection: selectionBinding) {
+            ForEach(items, id: \.self) { item in
+                content(item).tag(item as Item?)
+            }
+        }
+        // Dots hidden so the viewer stays clean; callers show their own position UI where needed.
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        #else
+        MacMediaPager(items: items, selection: selectionBinding, content: content)
+        #endif
+    }
+}
+
+#if os(macOS)
+/// macOS has no swipe to teach a pager affordance, so the arrows and dots stay visible
+/// rather than appearing only on hover.
+private struct MacMediaPager<Item: Hashable, ItemContent: View>: View {
+    let items: [Item]
+    @Binding var selection: Item?
+    let content: (Item) -> ItemContent
+
+    private var currentIndex: Int? {
+        guard let selection else { return nil }
+        return items.firstIndex(of: selection)
+    }
+
+    var body: some View {
+        ZStack {
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 0) {
+                    ForEach(items, id: \.self) { item in
+                        content(item)
+                            .containerRelativeFrame(.horizontal)
+                            .id(item)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollTargetBehavior(.paging)
+            .scrollPosition(id: $selection)
+            .scrollDisabled(items.count <= 1)
+
+            if items.count > 1 {
+                HStack {
+                    pagerArrow(systemName: "chevron.left", enabled: (currentIndex ?? 0) > 0) { step(-1) }
+                    Spacer()
+                    pagerArrow(systemName: "chevron.right", enabled: (currentIndex ?? 0) < items.count - 1) { step(1) }
+                }
+                .padding(.horizontal, 12)
+                .allowsHitTesting(true)
+
+                VStack {
+                    Spacer()
+                    pageDots
+                        .padding(.bottom, 10)
+                }
+                .allowsHitTesting(false)
+            }
+        }
+        .focusable()
+        .onKeyPress(.leftArrow) { step(-1); return .handled }
+        .onKeyPress(.rightArrow) { step(1); return .handled }
+        .onAppear {
+            if selection == nil { selection = items.first }
+        }
+    }
+
+    private func step(_ delta: Int) {
+        guard let idx = currentIndex else {
+            selection = items.first
+            return
+        }
+        let next = idx + delta
+        guard items.indices.contains(next) else { return }
+        withAnimation(Motion.pick) { selection = items[next] }
+    }
+
+    private func pagerArrow(systemName: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(Color.black.opacity(0.45)))
+                .overlay(Circle().stroke(Color.borderHairline, lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+        .opacity(enabled ? 1 : 0.35)
+        .disabled(!enabled)
+        .animation(Motion.chrome, value: enabled)
+    }
+
+    private var pageDots: some View {
+        HStack(spacing: 6) {
+            ForEach(items.indices, id: \.self) { i in
+                let isCurrent = i == (currentIndex ?? 0)
+                Circle()
+                    .fill(isCurrent ? Color.white : Color.white.opacity(0.35))
+                    .frame(width: isCurrent ? 6 : 5, height: isCurrent ? 6 : 5)
+            }
+        }
+        .animation(Motion.pick, value: currentIndex)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Capsule().fill(Color.black.opacity(0.45)))
+    }
+}
+#endif

--- a/HavenApp/HavenApp/Views/NoteDetailView.swift
+++ b/HavenApp/HavenApp/Views/NoteDetailView.swift
@@ -796,7 +796,9 @@ struct NoteDetailView: View {
                 )
                 .frame(maxWidth: .infinity)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                #if os(iOS)
                 .transition(.opacity.animation(Motion.media))
+                #endif
             }
             .frame(height: 400)
             .padding(.top, 4)

--- a/HavenApp/HavenApp/Views/NoteDetailView.swift
+++ b/HavenApp/HavenApp/Views/NoteDetailView.swift
@@ -787,20 +787,17 @@ struct NoteDetailView: View {
             .frame(maxWidth: .infinity)
             .padding(.top, 4)
         } else {
-            TabView {
-                ForEach(urls, id: \.absoluteString) { url in
-                    FeedMediaView(
-                        url: url,
-                        onTap: { showingMediaUrl = IdentifiableURL(url: url, allURLs: urls) },
-                        maxHeight: 400,
-                        isThumbnail: false
-                    )
-                    .frame(maxWidth: .infinity)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .transition(.opacity.animation(Motion.media))
-                }
+            MediaPagerView(items: urls) { url in
+                FeedMediaView(
+                    url: url,
+                    onTap: { showingMediaUrl = IdentifiableURL(url: url, allURLs: urls) },
+                    maxHeight: 400,
+                    isThumbnail: false
+                )
+                .frame(maxWidth: .infinity)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .transition(.opacity.animation(Motion.media))
             }
-            .mediaTabViewStyleCompat()
             .frame(height: 400)
             .padding(.top, 4)
         }

--- a/HavenApp/HavenApp/Views/PlatformCompat.swift
+++ b/HavenApp/HavenApp/Views/PlatformCompat.swift
@@ -215,17 +215,6 @@ extension View {
         }
     }
 
-    @ViewBuilder
-    func mediaTabViewStyleCompat() -> some View {
-        #if os(iOS)
-        // Page style = horizontal swiping. Without it, iOS renders the TabView
-        // as a (glass, on iOS 26) bottom tab bar with a "More" overflow list.
-        // Dots hidden so the viewer stays clean.
-        self.tabViewStyle(.page(indexDisplayMode: .never))
-        #else
-        self
-        #endif
-    }
 }
 
 #if os(iOS)

--- a/HavenApp/HavenApp/Views/ProfileView.swift
+++ b/HavenApp/HavenApp/Views/ProfileView.swift
@@ -1240,14 +1240,10 @@ struct ProfileView: View {
 
                 Spacer()
 
-                TabView(selection: $selectedMedia) {
-                    ForEach(displayMedia) { mediaItem in
-                        ViewerViewMediaItem(mediaItem: mediaItem)
-                            .tag(mediaItem as MediaItem?)
-                            .transition(.opacity.animation(Motion.media))
-                    }
+                MediaPagerView(items: displayMedia, selection: $selectedMedia) { mediaItem in
+                    ViewerViewMediaItem(mediaItem: mediaItem)
+                        .transition(.opacity.animation(Motion.media))
                 }
-                .mediaTabViewStyleCompat()
                 .animation(Motion.pick, value: selectedMedia?.id)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .offset(y: dragOffset.height)

--- a/HavenApp/HavenApp/Views/ProfileView.swift
+++ b/HavenApp/HavenApp/Views/ProfileView.swift
@@ -1240,11 +1240,12 @@ struct ProfileView: View {
 
                 Spacer()
 
-                MediaPagerView(items: displayMedia, selection: $selectedMedia) { mediaItem in
+                MediaPagerView(items: displayMedia, selection: $selectedMedia, enableKeyboardNavigation: true) { mediaItem in
                     ViewerViewMediaItem(mediaItem: mediaItem)
+                        #if os(iOS)
                         .transition(.opacity.animation(Motion.media))
+                        #endif
                 }
-                .animation(Motion.pick, value: selectedMedia?.id)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .offset(y: dragOffset.height)
                 .scaleEffect(max(0.8, 1.0 - (abs(dragOffset.height) / 1000.0)))

--- a/HavenApp/HavenApp/Views/Vault/VaultNoteRow.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultNoteRow.swift
@@ -380,14 +380,11 @@ struct NoteRow: View {
                         FeedMediaView(url: urls[0], maxHeight: 300, portraitMaxHeight: 400, isThumbnail: false)
                             .clipShape(RoundedRectangle(cornerRadius: 8))
                     } else {
-                        TabView {
-                            ForEach(urls, id: \.absoluteString) { url in
-                                FeedMediaView(url: url, maxHeight: 300, portraitMaxHeight: 400, isThumbnail: false)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                                    .transition(.opacity.animation(Motion.media))
-                            }
+                        MediaPagerView(items: urls) { url in
+                            FeedMediaView(url: url, maxHeight: 300, portraitMaxHeight: 400, isThumbnail: false)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .transition(.opacity.animation(Motion.media))
                         }
-                        .mediaTabViewStyleCompat()
                         .frame(height: 300)
                     }
                 }
@@ -717,14 +714,11 @@ struct RepostedNoteView: View {
                     FeedMediaView(url: urls[0], maxHeight: 250, portraitMaxHeight: 350, isThumbnail: false)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                 } else {
-                    TabView {
-                        ForEach(urls.prefix(4), id: \.absoluteString) { url in
-                            FeedMediaView(url: url, maxHeight: 250, portraitMaxHeight: 350, isThumbnail: false)
-                                .clipShape(RoundedRectangle(cornerRadius: 6))
-                                .transition(.opacity.animation(Motion.media))
-                        }
+                    MediaPagerView(items: Array(urls.prefix(4))) { url in
+                        FeedMediaView(url: url, maxHeight: 250, portraitMaxHeight: 350, isThumbnail: false)
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .transition(.opacity.animation(Motion.media))
                     }
-                    .mediaTabViewStyleCompat()
                     .frame(height: 250)
                 }
             }

--- a/HavenApp/HavenApp/Views/Vault/VaultNoteRow.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultNoteRow.swift
@@ -383,7 +383,9 @@ struct NoteRow: View {
                         MediaPagerView(items: urls) { url in
                             FeedMediaView(url: url, maxHeight: 300, portraitMaxHeight: 400, isThumbnail: false)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                                #if os(iOS)
                                 .transition(.opacity.animation(Motion.media))
+                                #endif
                         }
                         .frame(height: 300)
                     }
@@ -717,7 +719,9 @@ struct RepostedNoteView: View {
                     MediaPagerView(items: Array(urls.prefix(4))) { url in
                         FeedMediaView(url: url, maxHeight: 250, portraitMaxHeight: 350, isThumbnail: false)
                             .clipShape(RoundedRectangle(cornerRadius: 6))
+                            #if os(iOS)
                             .transition(.opacity.animation(Motion.media))
+                            #endif
                     }
                     .frame(height: 250)
                 }


### PR DESCRIPTION
## Summary
- macOS multi-image notes drew an unlabelled row of tab buttons instead of a pager — `TabView(selection:)`'s `.page` style is unavailable on macOS, `TabViewStyle` can't be conformed to by third parties in this SDK (its requirements are private view-graph SPI, verified against the SDK's `.swiftinterface`), and there's no `NSTabView` behind it to introspect (verified empirically: the automatic macOS style renders through SwiftUI's own layer-based renderer, not real AppKit)
- Added `MediaPagerView<Item, Content>` (`Views/MediaPagerView.swift`) that owns the platform split itself instead of being a modifier bolted onto an already-built `TabView`: `TabView` + `.page` on iOS (unchanged behavior), a paged `ScrollView(.horizontal)` on macOS with visible prev/next arrow buttons, page dots, and left/right arrow-key navigation — visible rather than hover-only since macOS has no swipe to teach the affordance
- Ported all 5 call sites (FeedView, NoteDetailView, ProfileView, MediaGalleryViewer's full-screen viewer, VaultNoteRow) onto it and removed the now-dead `mediaTabViewStyleCompat()` shim

## Note on "no call-site changes"
The original ask was a shim swap with no call-site changes. That turned out to not be achievable for a real interactive fix — SwiftUI gives no supported way to decompose or restyle a `TabView` from outside the view that builds it in this SDK. The call-site change here is mechanical (same shape: items array + selection binding + content closure), not a redesign.

## Test plan
- [x] `just macos-build` (HavenApp scheme) — clean, no new warnings
- [x] `just ios-build` (HavenApp-iOS scheme) — clean, unchanged iOS behavior (still `.page` style)
- [x] `just check-project` — project.yml and the committed `.xcodeproj` agree
- [x] `swiftc` `ImageRenderer` harness (ScrollView swapped for a static slice per its layout limitation) renders the macOS chrome — arrows + page dots — in place of the old blank tab strip
- [ ] Logen/Tory to eyeball the real pager on-device across the 5 surfaces at narrow and wide window widths

Fixes the macOS half of the multi-image pager issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)