### PR TITLE
Android: use the dropped handlers or delete them

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/AvatarImage.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/AvatarImage.kt
@@ -67,7 +67,6 @@ fun AvatarImage(
     size: Dp,
     modifier: Modifier = Modifier,
     displayName: String? = null,
-    onClick: (() -> Unit)? = null,
 ) {
     val gradient = remember(pubkey) { avatarGradient(pubkey) }
     val letter = remember(displayName, pubkey) {

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NostrContentText.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NostrContentText.kt
@@ -31,7 +31,6 @@ fun NostrContentText(
     profiles: Map<String, FeedProfile>,
     mediaURLs: Set<String> = emptySet(),
     onProfileClick: (String) -> Unit = {},
-    onNoteClick: (String) -> Unit = {},
     onPlainTextClick: (() -> Unit)? = null,
     textColor: Color = PrimaryText,
     fontSize: TextUnit = 15.sp,

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteCard.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteCard.kt
@@ -305,7 +305,6 @@ fun NoteCard(
                     fontSize = 17.sp,
                     lineHeight = 24.sp,
                     onProfileClick = onProfileClick,
-                    onNoteClick = onNoteClick,
                     onPlainTextClick = { onNoteClick(note.id) },
                     modifier = Modifier.padding(start = 50.dp),
                 )

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/VaultNoteCard.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/VaultNoteCard.kt
@@ -397,7 +397,6 @@ private fun ExpandedLayout(
                 profiles = profiles,
                 mediaURLs = note.mediaURLs.toSet(),
                 onProfileClick = onProfileClick,
-                onNoteClick = onNoteClick,
                 onPlainTextClick = { onNoteClick(note.id) },
                 lineHeight = 20.sp,
             )

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/navigation/NavGraph.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/navigation/NavGraph.kt
@@ -210,9 +210,6 @@ fun NostrVaultNavHost(
                     onNavigateToSettings = {
                         navController.navigate(Screen.Settings.route)
                     },
-                    onNavigateToDashboard = {
-                        navController.navigate(Screen.Dashboard.route)
-                    },
                 )
             }
 
@@ -611,13 +608,6 @@ fun NostrVaultNavHost(
                     onProfileClick = { pubkey ->
                         navController.navigate(Screen.Profile.createRoute(pubkey))
                     },
-                    onCompose = {
-                        navController.navigate(Screen.ComposeNote.createRoute())
-                    },
-                    onReply = { noteId ->
-                        navController.navigate(Screen.ComposeNote.createRoute(replyToNoteId = noteId))
-                    },
-                    onBack = { navController.popBackStack() },
                     logStore = logStore,
                     feedService = feedService,
                 )

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/DashboardScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/DashboardScreen.kt
@@ -1713,9 +1713,6 @@ fun DashboardScreen(
     /** Where a quoted long-form post opens; the note screen shows Markdown source. */
     onArticleClick: (String) -> Unit,
     onProfileClick: (String) -> Unit,
-    onCompose: () -> Unit,
-    onReply: (String) -> Unit,
-    onBack: () -> Unit,
     logStore: com.nostrvault.relay.LogStore,
     feedService: com.nostrvault.service.FeedService,
     viewModel: DashboardViewModel = hiltViewModel(),

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/MediaGalleryScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/MediaGalleryScreen.kt
@@ -361,6 +361,12 @@ fun MediaGalleryScreen(
         uri?.let { viewModel.uploadMedia(it, context.contentResolver) }
     }
 
+    // A blob carries no note reference; the sha256 is the only join. Resolved
+    // here rather than in the ViewModel because the gallery already holds the
+    // FeedService and this is a pure read of its cache.
+    val loadedNotes by feedService.notes.collectAsState()
+    val noteIdByHash = remember(loadedNotes) { noteIdsByBlobHash(loadedNotes) }
+
     val filteredItems = remember(mediaItems, activeFilter) {
         mediaItems
             .filter { item ->
@@ -550,6 +556,8 @@ fun MediaGalleryScreen(
                             item = item,
                             index = index,
                             contextMenuTarget = contextMenuTarget,
+                            noteId = noteIdByHash[item.sha256.lowercase()],
+                            onNoteClick = onNoteClick,
                             onTap = {
                                 MediaGalleryBridge.currentItems = filteredItems
                                 onMediaClick(index)
@@ -582,6 +590,8 @@ fun MediaGalleryScreen(
                             item = item,
                             index = index,
                             contextMenuTarget = contextMenuTarget,
+                            noteId = noteIdByHash[item.sha256.lowercase()],
+                            onNoteClick = onNoteClick,
                             onTap = {
                                 MediaGalleryBridge.currentItems = filteredItems
                                 onMediaClick(index)
@@ -605,6 +615,8 @@ private fun MediaGridCell(
     item: BlossomMediaItem,
     index: Int,
     contextMenuTarget: Int?,
+    noteId: String?,
+    onNoteClick: (String) -> Unit,
     onTap: () -> Unit,
     onLongPress: () -> Unit,
     onDismissMenu: () -> Unit,
@@ -659,6 +671,8 @@ private fun MediaGridCell(
         MediaItemContextMenu(
             expanded = contextMenuTarget == index,
             item = item,
+            noteId = noteId,
+            onNoteClick = onNoteClick,
             onDismiss = onDismissMenu,
             mediaCacheService = mediaCacheService,
             clipboardManager = clipboardManager,
@@ -673,6 +687,8 @@ private fun MediaListRow(
     item: BlossomMediaItem,
     index: Int,
     contextMenuTarget: Int?,
+    noteId: String?,
+    onNoteClick: (String) -> Unit,
     onTap: () -> Unit,
     onLongPress: () -> Unit,
     onDismissMenu: () -> Unit,
@@ -780,6 +796,8 @@ private fun MediaListRow(
         MediaItemContextMenu(
             expanded = contextMenuTarget == index,
             item = item,
+            noteId = noteId,
+            onNoteClick = onNoteClick,
             onDismiss = onDismissMenu,
             mediaCacheService = mediaCacheService,
             clipboardManager = clipboardManager,
@@ -792,6 +810,8 @@ private fun MediaListRow(
 private fun MediaItemContextMenu(
     expanded: Boolean,
     item: BlossomMediaItem,
+    noteId: String?,
+    onNoteClick: (String) -> Unit,
     onDismiss: () -> Unit,
     mediaCacheService: MediaCacheService,
     clipboardManager: androidx.compose.ui.platform.ClipboardManager,
@@ -802,6 +822,21 @@ private fun MediaItemContextMenu(
         expanded = expanded,
         onDismissRequest = onDismiss,
     ) {
+        // Only offered when a loaded note actually references this blob. An
+        // always-present item that does nothing for most files would be the same
+        // dead affordance in a different shape.
+        if (noteId != null) {
+            DropdownMenuItem(
+                text = { Text("Open Note") },
+                leadingIcon = {
+                    Icon(NostrVaultIcons.Articles, contentDescription = null, modifier = Modifier.size(20.dp))
+                },
+                onClick = {
+                    onDismiss()
+                    onNoteClick(noteId)
+                },
+            )
+        }
         DropdownMenuItem(
             text = { Text("Copy Link") },
             leadingIcon = {

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/MediaNoteIndex.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/MediaNoteIndex.kt
@@ -1,0 +1,50 @@
+package com.nostrvault.ui.screens
+
+import com.nostrvault.data.model.FeedNote
+
+/**
+ * Maps a Blossom blob back to the note that posted it.
+ *
+ * The media gallery lists *blobs* — files on your local Blossom directory and
+ * its mirrors. A blob carries no note reference, because nothing put one there:
+ * `BlossomMediaItem.noteId` has a `null` default and no construction site ever
+ * passes it. So "open the note behind this media item" had no data behind it,
+ * not just a missing wire.
+ *
+ * The join that does exist is the sha256. A Blossom URL is `<server>/<hash>`
+ * with an optional extension, so a note's `mediaURLs` carry the hash of every
+ * blob they reference, and matching on the hash works across mirrors — the same
+ * file served from two servers has two URLs and one hash.
+ */
+private val SHA256_IN_URL = Regex("(?<![0-9a-fA-F])[0-9a-fA-F]{64}(?![0-9a-fA-F])")
+
+/** The 64-hex sha256 in a Blossom URL, or null if the URL does not carry one. */
+internal fun blobHashInUrl(url: String): String? =
+    SHA256_IN_URL.find(url.substringBefore('?').substringBefore('#'))
+        ?.value
+        ?.lowercase()
+
+/**
+ * hash → note id, for every blob referenced by a loaded note.
+ *
+ * When two notes reference the same blob the **oldest** wins: that is the post
+ * the file was uploaded for, and a later quote or repost of the same image is
+ * not where you meant to land. Ties break on id so the map is stable rather
+ * than dependent on the order notes happened to arrive.
+ */
+internal fun noteIdsByBlobHash(notes: List<FeedNote>): Map<String, String> {
+    val best = HashMap<String, FeedNote>()
+    for (note in notes) {
+        for (url in note.mediaURLs) {
+            val hash = blobHashInUrl(url) ?: continue
+            val existing = best[hash]
+            if (existing == null ||
+                note.createdAt < existing.createdAt ||
+                (note.createdAt == existing.createdAt && note.id < existing.id)
+            ) {
+                best[hash] = note
+            }
+        }
+    }
+    return best.mapValues { it.value.id }
+}

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
@@ -82,7 +82,6 @@ fun FeedScreen(
     onReply: ((String) -> Unit)? = null,
     onQuote: ((String) -> Unit)? = null,
     onNavigateToSettings: () -> Unit,
-    onNavigateToDashboard: () -> Unit,
     viewModel: FeedViewModel = hiltViewModel(),
 ) {
     val feedMode by viewModel.feedMode.collectAsState()

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/settings/SettingsScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/settings/SettingsScreen.kt
@@ -17,13 +17,8 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
-import com.nostrvault.data.local.ConfigStore
 import com.nostrvault.ui.navigation.Screen
 import com.nostrvault.ui.theme.*
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 
 /** App version string shown in the About section (mirrors iOS appVersion). */
 private val APP_VERSION = BuildConfig.VERSION_NAME
@@ -39,17 +34,6 @@ private const val PRIVACY_POLICY_URL = "https://nostrvault.app/privacy.html"
  * Main settings screen with grouped navigation items.
  * Port of SettingsView.swift iOS list layout (sections, order and labels mirror iOS).
  */
-@HiltViewModel
-class SettingsViewModel @Inject constructor(
-    private val configStore: ConfigStore,
-) : ViewModel() {
-    val config = configStore.config
-
-    fun togglePrefetchAvatars() {
-        configStore.update { it.copy(prefetchAvatars = !it.prefetchAvatars) }
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/settings/SettingsScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/settings/SettingsScreen.kt
@@ -55,7 +55,6 @@ class SettingsViewModel @Inject constructor(
 fun SettingsScreen(
     onNavigate: (Screen) -> Unit,
     onBack: () -> Unit,
-    viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     Scaffold(
         topBar = {

--- a/NostrVault/app/src/test/java/com/nostrvault/ui/screens/MediaNoteIndexTest.kt
+++ b/NostrVault/app/src/test/java/com/nostrvault/ui/screens/MediaNoteIndexTest.kt
@@ -1,0 +1,98 @@
+package com.nostrvault.ui.screens
+
+import com.nostrvault.data.model.FeedNote
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Date
+
+private const val HASH_A = "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+private const val HASH_B = "0f9e8d7c6b5a49382716f5e4d3c2b1a00f9e8d7c6b5a49382716f5e4d3c2b1a0"
+
+private fun note(id: String, at: Long, media: List<String>) = FeedNote(
+    id = id,
+    pubkey = "pub",
+    content = "",
+    createdAt = Date(at),
+    tags = emptyList(),
+    kind = 1,
+    isReply = false,
+    replyToPubkey = null,
+    parentEventId = null,
+    mediaURLs = media,
+    linkURLs = emptyList(),
+    quotedEventIds = emptyList(),
+    repostedEventId = null,
+)
+
+class MediaNoteIndexTest {
+
+    @Test
+    fun `pulls the sha256 out of a blossom url`() {
+        assertEquals(HASH_A, blobHashInUrl("https://blossom.example/$HASH_A"))
+        assertEquals(HASH_A, blobHashInUrl("https://blossom.example/$HASH_A.jpg"))
+        assertEquals(HASH_A, blobHashInUrl("https://blossom.example/$HASH_A?auth=x"))
+        assertEquals(HASH_A, blobHashInUrl("https://blossom.example/$HASH_A#frag"))
+    }
+
+    @Test
+    fun `uppercase hashes normalise, so a url and a blob list agree`() {
+        assertEquals(HASH_A, blobHashInUrl("https://blossom.example/${HASH_A.uppercase()}"))
+    }
+
+    @Test
+    fun `a url with no hash yields nothing`() {
+        assertNull(blobHashInUrl("https://example.com/photo.jpg"))
+        assertNull(blobHashInUrl("https://example.com/"))
+    }
+
+    @Test
+    fun `a hex run longer than 64 is not a sha256`() {
+        // Guards the boundary assertions in the regex. Without them this would
+        // match a 64-char window inside a longer hex string and index a blob
+        // that does not exist.
+        assertNull(blobHashInUrl("https://example.com/${"a".repeat(70)}"))
+    }
+
+    @Test
+    fun `indexes every blob a note references`() {
+        val index = noteIdsByBlobHash(
+            listOf(note("n1", 1000L, listOf("https://b/$HASH_A.png", "https://b/$HASH_B.png"))),
+        )
+        assertEquals(mapOf(HASH_A to "n1", HASH_B to "n1"), index)
+    }
+
+    @Test
+    fun `the oldest note wins when two reference the same blob`() {
+        val index = noteIdsByBlobHash(
+            listOf(
+                note("newer", 5000L, listOf("https://b/$HASH_A")),
+                note("older", 1000L, listOf("https://mirror/$HASH_A")),
+            ),
+        )
+        assertEquals("older", index[HASH_A])
+    }
+
+    @Test
+    fun `input order does not change the answer`() {
+        val a = note("newer", 5000L, listOf("https://b/$HASH_A"))
+        val b = note("older", 1000L, listOf("https://mirror/$HASH_A"))
+        assertEquals(noteIdsByBlobHash(listOf(a, b)), noteIdsByBlobHash(listOf(b, a)))
+    }
+
+    @Test
+    fun `same-second ties break on id, not arrival order`() {
+        val a = note("zzz", 1000L, listOf("https://b/$HASH_A"))
+        val b = note("aaa", 1000L, listOf("https://b/$HASH_A"))
+        assertEquals("aaa", noteIdsByBlobHash(listOf(a, b))[HASH_A])
+        assertEquals("aaa", noteIdsByBlobHash(listOf(b, a))[HASH_A])
+    }
+
+    @Test
+    fun `notes with no blossom media contribute nothing`() {
+        assertEquals(
+            emptyMap<String, String>(),
+            noteIdsByBlobHash(listOf(note("n1", 1L, listOf("https://example.com/cat.gif")))),
+        )
+    }
+}


### PR DESCRIPTION
Closes the `Android: handlers threaded through and dropped at the leaf composable` issue.

Seven parameters were declared on composables, in some cases handed a working lambda by the caller, and never referenced in the body.

## Wired up — `MediaGalleryScreen.onNoteClick`

The one with user-visible impact, and the issue's read of it needs a correction.

**This was not a dropped wire.** The gallery lists Blossom *blobs* — files in the local blossom directory (`loadLocalBlossomFiles`) and its mirrors (`mergeBlobs`). `BlossomMediaItem.noteId` has a `null` default and **no construction site ever passes it**. There was no note behind a media item to open. Wiring `onNoteClick` to `item.noteId` would have produced a menu item that was null for every file in the gallery.

The join that does exist is the **sha256**. A Blossom URL is `<server>/<hash>` with an optional extension, so a note's `mediaURLs` carry the hash of every blob they reference — and matching on the hash works across mirrors, where matching on the URL does not (same file, two servers, two URLs, one hash).

`MediaNoteIndex.kt` builds that map from the feed cache. The context menu gains **"Open Note"** only for blobs a loaded note actually references; an always-present item that did nothing for most files would be the same dead affordance in a different shape.

When two notes reference one blob the **oldest** wins — that is the post the file was uploaded for, not a later quote of the same image. Ties break on id so the map does not depend on the order notes happened to arrive.

## Deleted — six that had nothing to use

| Parameter | Why it goes |
|---|---|
| `FeedScreen.onNavigateToDashboard` | Dashboard is the "Relay" bottom-nav tab. The feed does not need its own route to it. |
| `DashboardScreen.onBack` | Same. The issue asked to confirm Dashboard is a root before touching this — it is, `NavGraph.TOP_LEVEL_ROUTES` and `BottomNavBar.kt:72`. |
| `DashboardScreen.onCompose` / `onReply` | The vault list is read-only: `VaultNoteCard` takes no engagement handlers at all, matching iOS `VaultView`. |
| `AvatarImage.onClick` | Every caller already works around it with an external `Modifier.clickable`. Dead API that looked live. |
| `NostrContentText.onNoteClick` | Dead by design — note references are stripped from the text and drawn as `QuotedNoteCard`. The real tap path is `onPlainTextClick`, which both call sites also pass. Removing it surfaced that both were passing *both*. |
| `SettingsScreen.viewModel` | Unused. |

## On the suggested lint rule

The issue proposes an `unused parameter on @Composable` lint so the next one is caught at compile time. Agreed, and it is the durable half of this issue — but it wants its own change (it will flag intentionally-unused parameters in previews and interface conformances, so it needs a baseline). Not doing it here.

## Verification

- `:app:compileDebugKotlin` clean.
- 9 tests on the hash index, **68/68** in the module.
- **Not verified on a device** — no Android device attached to this Mac right now. What needs opening: long-press a gallery item whose note is in the feed and confirm "Open Note" appears and lands, and confirm it is *absent* on a blob no loaded note references. Both halves matter; only checking the positive one would miss a menu item that is always there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)