### PR TITLE
Android: stop the feed cropping multi-image notes and jumping as they load

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/MediaAspect.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/MediaAspect.kt
@@ -1,0 +1,74 @@
+package com.nostrvault.ui.components
+
+/**
+ * Known aspect ratios for note media, so the feed can reserve the right box
+ * *before* an image decodes instead of growing into it afterwards.
+ *
+ * A feed that reserves 200dp and then re-lays-out to the decoded ratio shifts
+ * everything below each image once, by up to 400dp, exactly as you are reading
+ * it. There are only two ways to avoid that: be told the size, or remember it.
+ * Both are here.
+ */
+
+/**
+ * Width ÷ height from a NIP-92 `imeta` tag's `dim <w>x<h>` field, or null.
+ *
+ * `imeta` is a flat tag: `["imeta", "url https://…", "dim 3024x4032", "m image/jpeg"]`.
+ * This app's own composer does not write one, so this covers notes from clients
+ * that do — which is most of them.
+ */
+internal fun imetaAspectRatio(tags: List<List<String>>, url: String): Float? {
+    for (tag in tags) {
+        if (tag.firstOrNull() != "imeta" || tag.size < 2) continue
+        val fields = tag.drop(1)
+        val tagUrl = fields.firstOrNull { it.startsWith("url ") }?.removePrefix("url ")?.trim()
+        if (tagUrl != url) continue
+        val dim = fields.firstOrNull { it.startsWith("dim ") }?.removePrefix("dim ")?.trim()
+            ?: continue
+        val parts = dim.split('x', 'X')
+        if (parts.size != 2) continue
+        val w = parts[0].trim().toFloatOrNull() ?: continue
+        val h = parts[1].trim().toFloatOrNull() ?: continue
+        if (w <= 0f || h <= 0f) continue
+        return w / h
+    }
+    return null
+}
+
+/**
+ * Ratios learned from images this process has already decoded.
+ *
+ * A `LazyColumn` disposes and recomposes rows as you scroll, so without this the
+ * *same* image shifts the feed again every time it comes back. Bounded, because
+ * a long session touches a lot of URLs and this is a convenience, not a cache of
+ * anything expensive.
+ *
+ * Not persisted: a wrong remembered ratio would be a permanent layout bug for
+ * that note, and the cost of relearning it is one decode the app is doing anyway.
+ */
+internal object MediaAspectCache {
+    private const val MAX_ENTRIES = 512
+    private val ratios = object : LinkedHashMap<String, Float>(64, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Float>?): Boolean =
+            size > MAX_ENTRIES
+    }
+
+    @Synchronized
+    fun get(url: String): Float? = ratios[url]
+
+    @Synchronized
+    fun put(url: String, ratio: Float) {
+        if (ratio > 0f && ratio.isFinite()) ratios[url] = ratio
+    }
+
+    @Synchronized
+    fun clear() = ratios.clear()
+}
+
+/**
+ * The best ratio available without decoding: what the author told us, else what
+ * we learned earlier this session, else null (reserve a default and accept one
+ * shift the first time this URL is seen).
+ */
+internal fun knownAspectRatio(tags: List<List<String>>, url: String): Float? =
+    imetaAspectRatio(tags, url) ?: MediaAspectCache.get(url)

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteCard.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteCard.kt
@@ -139,11 +139,17 @@ fun NoteCard(
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = SecondaryGroupedBg.copy(alpha = 0.85f),
+        // Unfocused cards get a neutral hairline, not accent-at-18%. Every card in
+        // the feed carrying an orange outline spends the accent on structure,
+        // which is what the accent is for drawing the eye *away* from. Focus
+        // still gets the accent, at full strength, where it means something.
         border = BorderStroke(
             if (isFocused) 2.dp else if (isOled) 1.dp else 0.8.dp,
-            if (isFocused) colors.primary else colors.primary.copy(alpha = if (isOled) 0.18f else 0.12f),
+            if (isFocused) colors.primary else SeparatorColor.copy(alpha = if (isOled) 0.9f else 0.6f),
         ),
-        shadowElevation = if (isFocused) 8.dp else 0.dp,
+        // No shadow: 8dp of it is not legible on a near-black surface. The 2dp
+        // accent border above is what says "focused".
+        shadowElevation = 0.dp,
         modifier = modifier
             .fillMaxWidth()
             .then(connectorModifier)
@@ -350,6 +356,7 @@ fun NoteCard(
                 Spacer(Modifier.height(8.dp))
                 MediaPreviewRow(
                     urls = note.mediaURLs,
+                    tags = note.tags,
                     modifier = Modifier.padding(start = 50.dp),
                 )
             }
@@ -568,17 +575,21 @@ internal fun isVideoUrl(url: String): Boolean {
 @Composable
 fun MediaPreviewRow(
     urls: List<String>,
+    /** The note's tags, read for NIP-92 `imeta dim` so the box is right first time. */
+    tags: List<List<String>> = emptyList(),
     modifier: Modifier = Modifier,
 ) {
     if (urls.size == 1) {
         SingleMediaPreview(
             url = urls.first(),
+            tags = tags,
             onMediaClick = { FullScreenMediaRouter.open(urls, 0) },
             modifier = modifier,
         )
     } else {
         MediaCarousel(
             urls = urls,
+            tags = tags,
             onMediaClick = { index -> FullScreenMediaRouter.open(urls, index) },
             modifier = modifier,
         )
@@ -859,16 +870,15 @@ class FeedMediaMirrorViewModel @Inject constructor(
 @Composable
 private fun SingleMediaPreview(
     url: String,
+    tags: List<List<String>>,
     onMediaClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val isVideo = isVideoUrl(url)
 
-    // Size to the media's natural aspect ratio — the decoded image, or a
-    // video's first frame via Coil VideoFrameDecoder — capped at 400dp
-    // landscape / 600dp portrait. Matches iOS FeedMediaView (Fit, no crop).
-    // Before load, reserve a 200dp placeholder.
+    // Size to the media's natural aspect ratio — capped at 400dp landscape /
+    // 600dp portrait. Matches iOS FeedMediaView (Fit, no crop).
     val painter = rememberAsyncImagePainter(
         model = ImageRequest.Builder(context)
             .data(url)
@@ -876,10 +886,25 @@ private fun SingleMediaPreview(
             .crossfade(100)
             .build(),
     )
-    val ratio = (painter.state as? AsyncImagePainter.State.Success)?.let {
+    val decodedRatio = (painter.state as? AsyncImagePainter.State.Success)?.let {
         val size = painter.intrinsicSize
         if (size.width > 0f && size.height > 0f) size.width / size.height else null
     }
+
+    // What the author told us, or what an earlier decode taught us. With either,
+    // the box is right before the bytes arrive and nothing below this note moves.
+    val hintedRatio = remember(url, tags) { knownAspectRatio(tags, url) }
+
+    // Remember what we decode so this URL never shifts the feed again, however
+    // many times the LazyColumn recycles the row.
+    LaunchedEffect(url, decodedRatio) {
+        decodedRatio?.let { MediaAspectCache.put(url, it) }
+    }
+
+    // The hint wins while it exists, so the height does not change *again* when
+    // the decode lands and reports a ratio a rounded `dim` disagrees with by a
+    // pixel.
+    val ratio = hintedRatio ?: decodedRatio
 
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
         val cap = if (ratio != null && ratio < 1f) 600.dp else 400.dp
@@ -914,18 +939,30 @@ private fun SingleMediaPreview(
 @Composable
 private fun MediaCarousel(
     urls: List<String>,
+    tags: List<List<String>>,
     onMediaClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val pagerState = rememberPagerState(pageCount = { urls.size })
 
+    // A pager has one height for every page, so the ratio comes from the first
+    // image — the one you see before you swipe. Pages are drawn Fit inside it,
+    // which letterboxes the others rather than cropping them.
+    //
+    // This used to be a hard `aspectRatio(4f / 3f)` with `ContentScale.Crop`, so
+    // a portrait photo displayed whole when posted alone and was centre-cropped
+    // into a landscape box the moment a second image joined it. Faces and text
+    // went off the edges of the same file that rendered fine on its own.
+    val firstRatio = remember(urls, tags) { knownAspectRatio(tags, urls.first()) }
+    val pagerRatio = (firstRatio ?: (4f / 3f)).coerceIn(2f / 3f, 16f / 9f)
+
     Column(modifier = modifier) {
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(4f / 3f)
+                .aspectRatio(pagerRatio)
                 .clip(RoundedCornerShape(8.dp)),
         ) { page ->
             val url = urls[page]
@@ -943,7 +980,16 @@ private fun MediaCarousel(
                         .crossfade(100)
                         .build(),
                     contentDescription = null,
-                    contentScale = ContentScale.Crop,
+                    contentScale = ContentScale.Fit,
+                    onSuccess = { result ->
+                        val d = result.result.drawable
+                        if (d.intrinsicWidth > 0 && d.intrinsicHeight > 0) {
+                            MediaAspectCache.put(
+                                url,
+                                d.intrinsicWidth.toFloat() / d.intrinsicHeight.toFloat(),
+                            )
+                        }
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
                 if (isVideoUrl(url)) {

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/VaultNoteCard.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/VaultNoteCard.kt
@@ -405,7 +405,7 @@ private fun ExpandedLayout(
 
         // Media previews (iOS lines 314-330)
         if (note.mediaURLs.isNotEmpty()) {
-            MediaPreviewRow(urls = note.mediaURLs)
+            MediaPreviewRow(urls = note.mediaURLs, tags = note.tags)
         }
 
         // Quoted events. This card already knew a quote existed — it suppressed

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/NoteDetailScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/NoteDetailScreen.kt
@@ -1413,7 +1413,7 @@ private fun HeroNoteCard(
 
             // Media
             if (note.mediaURLs.isNotEmpty()) {
-                MediaPreviewRow(urls = note.mediaURLs)
+                MediaPreviewRow(urls = note.mediaURLs, tags = note.tags)
                 Spacer(Modifier.height(12.dp))
             }
 

--- a/NostrVault/app/src/test/java/com/nostrvault/ui/components/MediaAspectTest.kt
+++ b/NostrVault/app/src/test/java/com/nostrvault/ui/components/MediaAspectTest.kt
@@ -1,0 +1,89 @@
+package com.nostrvault.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+private const val URL = "https://blossom.example/photo.jpg"
+private const val OTHER = "https://blossom.example/other.jpg"
+
+class MediaAspectTest {
+
+    @Before
+    fun reset() = MediaAspectCache.clear()
+
+    @Test
+    fun `reads dim from the imeta tag for the matching url`() {
+        val tags = listOf(listOf("imeta", "url $URL", "dim 3024x4032", "m image/jpeg"))
+        assertEquals(3024f / 4032f, imetaAspectRatio(tags, URL)!!, 1e-6f)
+    }
+
+    @Test
+    fun `a dim belonging to a different url is not used`() {
+        // The failure this guards is the one that matters: a note with two
+        // images would otherwise size the second from the first's dimensions.
+        val tags = listOf(listOf("imeta", "url $OTHER", "dim 4032x3024"))
+        assertNull(imetaAspectRatio(tags, URL))
+    }
+
+    @Test
+    fun `picks the right imeta out of several`() {
+        val tags = listOf(
+            listOf("imeta", "url $OTHER", "dim 4032x3024"),
+            listOf("imeta", "url $URL", "dim 1080x1920"),
+        )
+        assertEquals(1080f / 1920f, imetaAspectRatio(tags, URL)!!, 1e-6f)
+    }
+
+    @Test
+    fun `an imeta with no dim yields nothing rather than a default`() {
+        assertNull(imetaAspectRatio(listOf(listOf("imeta", "url $URL", "m image/jpeg")), URL))
+    }
+
+    @Test
+    fun `malformed dims are ignored`() {
+        for (dim in listOf("dim 3024", "dim x4032", "dim 0x100", "dim 100x0", "dim axb", "dim -3x4")) {
+            assertNull(dim, imetaAspectRatio(listOf(listOf("imeta", "url $URL", dim)), URL))
+        }
+    }
+
+    @Test
+    fun `non-imeta tags are skipped`() {
+        assertNull(imetaAspectRatio(listOf(listOf("e", "abc"), listOf("p"), emptyList()), URL))
+    }
+
+    @Test
+    fun `the cache answers for a url decoded earlier`() {
+        assertNull(knownAspectRatio(emptyList(), URL))
+        MediaAspectCache.put(URL, 1.5f)
+        assertEquals(1.5f, knownAspectRatio(emptyList(), URL)!!, 1e-6f)
+    }
+
+    @Test
+    fun `imeta beats the cache`() {
+        // A hint that changes after the decode lands would shift the feed a
+        // second time, which is the whole thing this is here to stop.
+        MediaAspectCache.put(URL, 1.5f)
+        val tags = listOf(listOf("imeta", "url $URL", "dim 1000x1000"))
+        assertEquals(1f, knownAspectRatio(tags, URL)!!, 1e-6f)
+    }
+
+    @Test
+    fun `the cache refuses a nonsense ratio`() {
+        MediaAspectCache.put(URL, 0f)
+        MediaAspectCache.put(URL, Float.NaN)
+        MediaAspectCache.put(URL, Float.POSITIVE_INFINITY)
+        assertNull(MediaAspectCache.get(URL))
+    }
+
+    @Test
+    fun `the cache is bounded and evicts least-recently-used`() {
+        MediaAspectCache.put("keep", 1f)
+        repeat(600) { MediaAspectCache.put("url$it", 1f) }
+        // "keep" was touched first and never again, so it is gone; the newest
+        // entries survive. Without a bound a long session grows without limit.
+        assertNull(MediaAspectCache.get("keep"))
+        assertEquals(1f, MediaAspectCache.get("url599")!!, 1e-6f)
+    }
+}


### PR DESCRIPTION
Closes the `Android: media cropping, feed layout shift, and unconfirmed draft delete` issue — defects 1, 2, 4 and 5. Defect 3 is closed by #27 (see below).

## 1. A multi-image note no longer crops

`MediaCarousel` (`NoteCard.kt:924-948`) forced `aspectRatio(4f / 3f)` with `ContentScale.Crop`, while `SingleMediaPreview` sized to the natural ratio with `Fit`. So the **same portrait photo** displayed whole when posted alone and was centre-cropped into a landscape box the moment a second image joined it. Faces and text went off the edges of a file that rendered fine on its own.

The pager now takes its height from the first image — the one you see before you swipe, and a pager has one height for every page — and draws every page `Fit`, letterboxing the others rather than cropping them.

## 2. The feed no longer jumps as images load

It reserved a 200dp placeholder (`:886`) and then re-laid-out to the decoded ratio, shifting everything below each image once by up to 400dp.

There are only two ways to avoid that: be told the size, or remember it. `MediaAspect.kt` does both.

- **NIP-92 `imeta dim WxH`**, when the author's client wrote one. This app's own composer does not write `imeta`, so this covers notes from clients that do — which is most of them.
- **A bounded in-process cache** of ratios learned from decodes. Without it the *same* image shifts the feed again every time the `LazyColumn` recycles the row, which in a scrolling feed is constantly.

The hint wins over the decode, so the height does not change a *second* time when a rounded `dim` disagrees with the decoded pixels by one.

Not persisted, deliberately: a wrong remembered ratio would be a permanent layout bug for that note, and relearning costs one decode the app is doing anyway.

**Honest limit:** a URL seen for the first time with no `imeta` still shifts once. That cannot be avoided without decoding first. It is now the only case rather than every case.

## 4 & 5. Card chrome

Every card was stroked with `colors.primary` at 18% (`:144`) — an orange outline on every row in the feed, spending the accent on structure, which is the thing the accent exists to draw the eye *away* from. Unfocused cards get a neutral hairline; focus keeps the accent at full strength, where it means something.

`shadowElevation = 8.dp` on the focused card (`:146`) is dropped. It is not legible on a near-black surface, and the 2dp accent border is what actually carries focus.

## 3. The unconfirmed draft delete

Fixed in **#27**, which deletes `DraftPickerSheet` entirely — that trash icon lived in it. The issue also asks to check `DraftsScreen.kt:223` for the same problem; I did, and it is swipe-to-delete, which is deliberate and matches iOS (`DraftPickerView.swift:116`). A swipe is a committed gesture, not a mis-tap beside the thing you meant to open.

## Verification

- `:app:compileDebugKotlin` clean.
- 10 tests, **69/69** in the module. The one that matters most: a `dim` belonging to a *different* URL is not used — without that check, a two-image note would size its second image from the first's dimensions.
- **Not verified on a device** — no Android device attached to this Mac right now. This is the change that most needs a real screen: post a portrait photo alone and again with a second image and confirm neither crops, then scroll a feed of unseen images and watch whether the content below settles. A compile and a unit test cannot see either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)