### PR TITLE
Android: make the Text Size setting do something

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/theme/NostrVaultTheme.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/theme/NostrVaultTheme.kt
@@ -6,8 +6,11 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 
 /**
  * CompositionLocal providing the current NostrVaultColorScheme.
@@ -26,8 +29,36 @@ val LocalAppTheme = staticCompositionLocalOf { AppTheme.DEFAULT }
 /**
  * CompositionLocal for the user's text size scale preference.
  * Defaults to 1.0 (no scaling).
+ *
+ * **Do not multiply a font size by this.** [NostrVaultTheme] applies the user's
+ * preference once, by overriding [androidx.compose.ui.platform.LocalDensity]'s
+ * `fontScale`, which scales every `sp` in the tree. A call site that also
+ * multiplies by this value would scale twice. It is exposed for code that needs
+ * to *read* the preference — to decide a layout, not a size.
  */
 val LocalTextSizeScale = staticCompositionLocalOf { 1.0f }
+
+/**
+ * The `fontScale` to hand [androidx.compose.ui.platform.LocalDensity] so the
+ * user's Text Size preference reaches every `sp` in the app.
+ *
+ * Multiplies rather than replaces: the system accessibility font scale is a
+ * separate setting the user also chose, and dropping it would make this control
+ * silently override the OS one.
+ *
+ * Clamped, because this arrives from persisted config rather than from the
+ * slider that produced it. A zero or negative scale renders every string in the
+ * app at zero height, which looks exactly like a blank screen.
+ */
+fun scaledFontScale(systemFontScale: Float, userScale: Float): Float {
+    val safeSystem = if (systemFontScale.isFinite() && systemFontScale > 0f) systemFontScale else 1f
+    val safeUser = if (userScale.isFinite()) userScale.coerceIn(MIN_TEXT_SCALE, MAX_TEXT_SCALE) else 1f
+    return safeSystem * safeUser
+}
+
+/** Widest the Text Size slider goes is 0.8–1.6; these bound a corrupt config, not the UI. */
+const val MIN_TEXT_SCALE = 0.5f
+const val MAX_TEXT_SCALE = 2.0f
 
 /**
  * CompositionLocal for OLED mode preference.
@@ -82,7 +113,34 @@ fun NostrVaultTheme(
         onError = Color.White,
     )
 
-    val typography = nostrVaultTypography(scale = textSizeScale)
+    // The ramp is installed unscaled. Scaling lives in exactly one place — the
+    // density override below — because two mechanisms would multiply: a slot that
+    // had already scaled itself would then be scaled again by the density.
+    val typography = nostrVaultTypography()
+
+    // This is what makes the Text Size setting do anything.
+    //
+    // The ramp was being built from the preference and installed as
+    // `MaterialTheme(typography = …)`, and then nothing read it:
+    // `MaterialTheme.typography` is referenced nowhere in the `ui/` tree, there
+    // is no `ProvideTextStyle`, and ~560 call sites pass `fontSize = <n>.sp`
+    // directly. Compose does not apply Typography slots on its own, so moving
+    // the slider changed a value no `Text` ever consulted.
+    //
+    // `sp` is resolved to pixels through the ambient Density's `fontScale`, so
+    // overriding it here reaches every `sp` in the tree at once — the hardcoded
+    // literals, the unstyled `Text`s on the Compose default, and the ramp if and
+    // when call sites migrate onto it. `dp` is untouched, so boxes keep their
+    // sizes and text growing inside a fixed-height row shows up as clipping
+    // rather than being silently absorbed. That is the honest failure mode and
+    // it is where a working ramp actually breaks layout.
+    val baseDensity = LocalDensity.current
+    val scaledDensity = remember(baseDensity, textSizeScale) {
+        Density(
+            density = baseDensity.density,
+            fontScale = scaledFontScale(baseDensity.fontScale, textSizeScale),
+        )
+    }
 
     CompositionLocalProvider(
         LocalNostrVaultColors provides colors,
@@ -90,6 +148,7 @@ fun NostrVaultTheme(
         LocalTextSizeScale provides textSizeScale,
         LocalOledMode provides oledMode,
         LocalZapsOnlyMode provides zapsOnlyMode,
+        LocalDensity provides scaledDensity,
     ) {
         MaterialTheme(
             colorScheme = materialColors,

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/theme/Type.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/theme/Type.kt
@@ -7,7 +7,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 /**
- * Port of Font.appSystem() scaling system from Theming.swift.
+ * The app's type ramp, a port of the semantic styles in Theming.swift.
+ *
+ * Unscaled, deliberately. The user's Text Size preference is applied once, by
+ * [NostrVaultTheme] overriding the ambient Density's `fontScale`, which reaches
+ * every `sp` in the tree including these. A `scale` parameter here would scale a
+ * second time.
+ *
+ * Installed as `MaterialTheme(typography = …)` but not yet read by call sites:
+ * `MaterialTheme.typography` appears nowhere in the `ui/` tree and ~560 places
+ * still pass `fontSize` literals. Migrating them onto these slots is real work
+ * and a visible restyle — several sizes in use (14, 10, 18) have no slot — so it
+ * is a separate task from making the setting work.
  *
  * Maps iOS semantic font styles to Material 3 Typography slots:
  *   displayLarge  = appLargeTitle (34sp)
@@ -22,68 +33,68 @@ import androidx.compose.ui.unit.sp
  *   bodySmall     = appCaption    (12sp)
  *   labelSmall    = appCaption2   (11sp)
  */
-fun nostrVaultTypography(scale: Float = 1.0f): Typography = Typography(
+fun nostrVaultTypography(): Typography = Typography(
     displayLarge = TextStyle(
-        fontSize = (34 * scale).sp,
+        fontSize = 34.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (41 * scale).sp,
+        lineHeight = 41.sp,
     ),
     headlineLarge = TextStyle(
-        fontSize = (28 * scale).sp,
+        fontSize = 28.sp,
         fontWeight = FontWeight.Bold,
-        lineHeight = (34 * scale).sp,
+        lineHeight = 34.sp,
     ),
     headlineMedium = TextStyle(
-        fontSize = (22 * scale).sp,
+        fontSize = 22.sp,
         fontWeight = FontWeight.Bold,
-        lineHeight = (28 * scale).sp,
+        lineHeight = 28.sp,
     ),
     headlineSmall = TextStyle(
-        fontSize = (20 * scale).sp,
+        fontSize = 20.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (25 * scale).sp,
+        lineHeight = 25.sp,
     ),
     titleLarge = TextStyle(
-        fontSize = (17 * scale).sp,
+        fontSize = 17.sp,
         fontWeight = FontWeight.SemiBold,
-        lineHeight = (22 * scale).sp,
+        lineHeight = 22.sp,
     ),
     titleMedium = TextStyle(
-        fontSize = (17 * scale).sp,
+        fontSize = 17.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (22 * scale).sp,
+        lineHeight = 22.sp,
     ),
     titleSmall = TextStyle(
-        fontSize = (16 * scale).sp,
+        fontSize = 16.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (21 * scale).sp,
+        lineHeight = 21.sp,
     ),
     bodyLarge = TextStyle(
-        fontSize = (15 * scale).sp,
+        fontSize = 15.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (20 * scale).sp,
+        lineHeight = 20.sp,
     ),
     bodyMedium = TextStyle(
-        fontSize = (13 * scale).sp,
+        fontSize = 13.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (18 * scale).sp,
+        lineHeight = 18.sp,
     ),
     bodySmall = TextStyle(
-        fontSize = (12 * scale).sp,
+        fontSize = 12.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (16 * scale).sp,
+        lineHeight = 16.sp,
     ),
     labelSmall = TextStyle(
-        fontSize = (11 * scale).sp,
+        fontSize = 11.sp,
         fontWeight = FontWeight.Normal,
-        lineHeight = (13 * scale).sp,
+        lineHeight = 13.sp,
     ),
 )
 
 /** Monospace variant for stats, amounts, hex strings, and code blocks. */
-fun monoTextStyle(scale: Float = 1.0f): TextStyle = TextStyle(
+fun monoTextStyle(): TextStyle = TextStyle(
     fontFamily = FontFamily.Monospace,
-    fontSize = (14 * scale).sp,
+    fontSize = 14.sp,
     fontWeight = FontWeight.Normal,
-    lineHeight = (18 * scale).sp,
+    lineHeight = 18.sp,
 )

--- a/NostrVault/app/src/test/java/com/nostrvault/ui/theme/TextScaleTest.kt
+++ b/NostrVault/app/src/test/java/com/nostrvault/ui/theme/TextScaleTest.kt
@@ -1,0 +1,59 @@
+package com.nostrvault.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TextScaleTest {
+
+    @Test
+    fun `the user preference multiplies the system font scale`() {
+        // Not replaces. The OS accessibility font size is a setting the user also
+        // chose; overriding it would make this control silently undo that one.
+        assertEquals(1.6f, scaledFontScale(systemFontScale = 1.0f, userScale = 1.6f), 1e-6f)
+        assertEquals(1.8f, scaledFontScale(systemFontScale = 1.5f, userScale = 1.2f), 1e-6f)
+    }
+
+    @Test
+    fun `the default preference changes nothing`() {
+        assertEquals(1.3f, scaledFontScale(systemFontScale = 1.3f, userScale = 1.0f), 1e-6f)
+    }
+
+    @Test
+    fun `the whole slider range passes through untouched`() {
+        // The control is 0.8-1.6, so the clamp must not be tighter than the UI.
+        assertEquals(0.8f, scaledFontScale(1f, 0.8f), 1e-6f)
+        assertEquals(1.6f, scaledFontScale(1f, 1.6f), 1e-6f)
+    }
+
+    @Test
+    fun `a corrupt preference cannot render the app at zero height`() {
+        // This value comes from persisted config, not from the slider that made
+        // it. Zero or negative would draw every string in the app at no height,
+        // which is indistinguishable from a blank screen.
+        assertEquals(MIN_TEXT_SCALE, scaledFontScale(1f, 0f), 1e-6f)
+        assertEquals(MIN_TEXT_SCALE, scaledFontScale(1f, -3f), 1e-6f)
+        assertEquals(MAX_TEXT_SCALE, scaledFontScale(1f, 99f), 1e-6f)
+    }
+
+    @Test
+    fun `a non-finite preference falls back rather than propagating NaN`() {
+        assertEquals(1f, scaledFontScale(1f, Float.NaN), 1e-6f)
+        assertEquals(1f, scaledFontScale(1f, Float.POSITIVE_INFINITY), 1e-6f)
+    }
+
+    @Test
+    fun `a broken system font scale does not take the preference down with it`() {
+        assertEquals(1.6f, scaledFontScale(systemFontScale = 0f, userScale = 1.6f), 1e-6f)
+        assertEquals(1.6f, scaledFontScale(systemFontScale = Float.NaN, userScale = 1.6f), 1e-6f)
+    }
+
+    @Test
+    fun `the ramp itself carries no scaling`() {
+        // Two mechanisms would multiply. The density override owns scaling, so
+        // these slots must stay at their design sizes.
+        val t = nostrVaultTypography()
+        assertEquals(34f, t.displayLarge.fontSize.value, 1e-6f)
+        assertEquals(17f, t.titleMedium.fontSize.value, 1e-6f)
+        assertEquals(11f, t.labelSmall.fontSize.value, 1e-6f)
+    }
+}


### PR DESCRIPTION
Closes the `Android: the Text Size setting does nothing` issue.

## The defect

Appearance settings has a Text Size slider (0.8–1.6). It persisted, `MainActivity:119` passed it into the theme, and `NostrVaultTheme.kt:85` built a scaled ramp from it and installed it as `MaterialTheme(typography = …)`.

Then nothing read the result. `MaterialTheme.typography` is referenced **0 times** in the `ui/` tree, there is no `ProvideTextStyle` anywhere, and ~560 call sites pass `fontSize = <n>.sp` directly. Compose does not apply Typography slots on its own, so moving the slider changed a value no `Text` ever consulted.

A shipped accessibility control that does nothing is worse than not having one: someone who needs larger type sets it, sees no change, and concludes the app cannot do it.

## The fix

`sp` is resolved to pixels through the ambient `Density`'s `fontScale`. The theme now overrides `LocalDensity` with the user's preference folded in, which reaches **every `sp` in the tree at once** — the hardcoded literals, the unstyled `Text`s sitting on the Compose default, and the ramp itself if and when call sites migrate onto it.

There is one composition root and one theme (`MainActivity:113`, and `NostrVaultTheme(`/`MaterialTheme(` appear nowhere else), so this covers the whole app including the setup wizard.

`dp` is untouched. Boxes keep their sizes, so text growing inside a fixed-height row shows up as **clipping** rather than being silently absorbed. That is the honest failure mode, and per the issue it is exactly where a working ramp breaks layout.

### One mechanism, not two

The ramp is now installed **unscaled**, and `nostrVaultTypography` / `monoTextStyle` lose their `scale` parameters. A slot that had already scaled itself would then be scaled again by the density. `LocalTextSizeScale` stays, with a doc comment saying not to multiply a font size by it — that is the same double-scale trap from the other direction.

### Clamped on the way in

The scale arrives from persisted config, not from the slider that produced it. Zero or negative renders every string in the app at zero height, which is indistinguishable from a blank screen. It **multiplies** the system accessibility font scale rather than replacing it — that is a setting the user also chose, and overriding it would make this control silently undo the OS one.

## What this deliberately does not do

Migrate the ~560 `fontSize` literals onto ramp slots (the issue's step 2).

That is a **visible restyle**, not a fix. The ramp has 34/28/22/20/17/16/15/13/12/11; the sizes actually in use include **14sp at 76 sites, 10sp at 25, 18sp at 13**, plus 9/24/26/30/32/48/56. Those have no slot to map to, so "replace the literal with the slot whose value it matches" means choosing new sizes for those screens — a design decision on every screen in the app, and one I cannot verify without a device.

It is also no longer blocked, which was the issue's stated reason for urgency: the ramp is in force for anything that adopts it, and the setting works today regardless. Worth its own issue.

## Verification

- 7 new tests. **72/72** in the module (`:app:testDebugUnitTest`) at `3459b45`, run in a pristine detached worktree at that exact sha, against a master baseline of 65.
- **Not verified on a device**, and this is the one where that matters most. The issue's verify step is the right one: set the slider to its largest value and walk feed → note detail → compose → settings → wizard, then check the smallest labels in fixed-height rows for clipping. `SetupWizardScreen.kt` (71 literals) and `BitcoinSweepScreen.kt` (31) are where I would look first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)