### PR TITLE
Android: one definition of a note's overflow menu

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteActionsMenu.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteActionsMenu.kt
@@ -1,0 +1,63 @@
+package com.nostrvault.ui.components
+
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.nostrvault.ui.theme.ErrorRed
+import com.nostrvault.ui.theme.PrimaryText
+
+/**
+ * One item in a note's overflow menu.
+ *
+ * [destructive] only colours the row; it carries no confirmation of its own.
+ * Anything that needs one still opens its dialog from [onClick], because the
+ * confirmation belongs to the action, not to the menu that launched it.
+ */
+@Immutable
+data class NoteAction(
+    val icon: ImageVector,
+    val label: String,
+    val destructive: Boolean = false,
+    val onClick: () -> Unit,
+)
+
+/**
+ * The overflow menu for a note. One definition, anchored to the button that
+ * opened it.
+ *
+ * There were two of these: an anchored [DropdownMenu] on the focused note in
+ * `NoteDetailScreen` and an `AlertDialog` in `FeedScreen` — same gesture, same
+ * screen once replies got a menu, two patterns. The anchored menu is the one
+ * that survived: it is Material's overflow affordance, and it keeps the
+ * connection to the note you tapped, which a modal dialog loses. (That lost
+ * anchor is also why the dialog's Cancel had drifted into `confirmButton`.)
+ *
+ * The item set is a parameter because it legitimately differs by surface — the
+ * focused note can follow and unfollow its author, a search result can only
+ * copy a link. What must not differ is the presentation, which is here.
+ */
+@Composable
+fun NoteActionsMenu(
+    expanded: Boolean,
+    actions: List<NoteAction>,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        for (action in actions) {
+            val tint: Color = if (action.destructive) ErrorRed else PrimaryText
+            DropdownMenuItem(
+                text = { Text(action.label, color = tint) },
+                onClick = {
+                    onDismiss()
+                    action.onClick()
+                },
+                leadingIcon = { Icon(action.icon, contentDescription = null, tint = tint) },
+            )
+        }
+    }
+}

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteCard.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/components/NoteCard.kt
@@ -28,8 +28,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -42,6 +44,8 @@ import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
+import android.widget.Toast
+import com.nostrvault.relay.HavenBridge
 import com.nostrvault.data.model.FeedNote
 import com.nostrvault.data.model.FeedProfile
 import com.nostrvault.data.model.NoteStats
@@ -94,12 +98,59 @@ fun NoteCard(
     onQuote: ((String) -> Unit)? = null,
     onShare: ((String) -> Unit)? = null,
     onBroadcast: ((String) -> Unit)? = null,
-    onMore: ((String) -> Unit)? = null,
+    /**
+     * Overflow-menu handlers. The menu is anchored to the card's own button, so
+     * the card owns it rather than a screen-level dialog keyed by note id.
+     *
+     * Copy link needs nothing from the caller and is always offered, so every
+     * card has a menu — a search result gets one item, the feed gets three.
+     */
+    isOwnNote: Boolean = false,
+    onReport: (() -> Unit)? = null,
+    onBlock: (() -> Unit)? = null,
+    onDelete: (() -> Unit)? = null,
     onLongPressLike: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val colors = LocalNostrVaultColors.current
     val isOled = LocalOledMode.current
+
+    // Overflow menu. Built here rather than by each screen so that the item
+    // order and wording are one definition; which items exist is the caller's,
+    // because a search result and the feed genuinely differ.
+    var showMoreMenu by remember { mutableStateOf(false) }
+    val menuContext = LocalContext.current
+    val menuClipboard = LocalClipboardManager.current
+    val moreActions = buildList {
+        add(
+            NoteAction(
+                icon = NostrVaultIcons.Share,
+                label = "Copy link",
+                onClick = {
+                    val nevent = HavenBridge.encodeNevent(
+                        note.effectiveEventId,
+                        note.pubkey,
+                        note.kind,
+                    ) ?: HavenBridge.hexToNote1(note.effectiveEventId)
+                        ?: note.effectiveEventId
+                    menuClipboard.setText(AnnotatedString(threadLink(nevent)))
+                    Toast.makeText(menuContext, "Link copied", Toast.LENGTH_SHORT).show()
+                },
+            ),
+        )
+        if (isOwnNote) {
+            onDelete?.let {
+                add(NoteAction(NostrVaultIcons.Delete, "Delete Post", destructive = true, onClick = it))
+            }
+        } else {
+            onReport?.let {
+                add(NoteAction(NostrVaultIcons.Alert, "Report", destructive = true, onClick = it))
+            }
+            onBlock?.let {
+                add(NoteAction(NostrVaultIcons.Blocked, "Block", destructive = true, onClick = it))
+            }
+        }
+    }
     val connectorColor = colors.primary.copy(alpha = 0.3f)
 
     // Thread connector lines drawn behind the card
@@ -259,8 +310,8 @@ fun NoteCard(
                 }
 
                 // More menu
-                onMore?.let { handler ->
-                    IconButton(onClick = { handler(note.id) }) {
+                Box {
+                    IconButton(onClick = { showMoreMenu = true }) {
                         Icon(
                             imageVector = NostrVaultIcons.More,
                             contentDescription = "More",
@@ -268,6 +319,11 @@ fun NoteCard(
                             modifier = Modifier.size(18.dp),
                         )
                     }
+                    NoteActionsMenu(
+                        expanded = showMoreMenu,
+                        actions = moreActions,
+                        onDismiss = { showMoreMenu = false },
+                    )
                 }
             }
 

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/NoteDetailScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/NoteDetailScreen.kt
@@ -486,10 +486,13 @@ fun NoteDetailScreen(
         context.startActivity(Intent.createChooser(intent, "Share Note"))
     }
 
-    // Delete confirmation
-    var showDeleteDialog by remember { mutableStateOf(false) }
-    var showBlockDialog by remember { mutableStateOf(false) }
-    var showReportDialog by remember { mutableStateOf(false) }
+    // Moderation confirmations. These hold the note they were opened for rather
+    // than a flag, because the overflow menu is now on every note on this screen
+    // and not only on the focused one. Acting on the focused note still leaves
+    // the screen — there is nothing left to look at; acting on a reply does not.
+    var deleteTarget by remember { mutableStateOf<FeedNote?>(null) }
+    var blockTarget by remember { mutableStateOf<FeedNote?>(null) }
+    var reportTarget by remember { mutableStateOf<FeedNote?>(null) }
 
     // Zap result feedback
     LaunchedEffect(Unit) {
@@ -560,60 +563,60 @@ fun NoteDetailScreen(
     }
 
     // Delete confirmation dialog
-    if (showDeleteDialog && focusedNote != null) {
+    deleteTarget?.let { target ->
         AlertDialog(
-            onDismissRequest = { showDeleteDialog = false },
+            onDismissRequest = { deleteTarget = null },
             title = { Text("Delete Post", color = PrimaryText) },
             text = { Text("Request deletion of this post? Not all relays honor NIP-09 deletion requests.", color = SecondaryText) },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        viewModel.deleteNote(focusedNote!!.id)
-                        showDeleteDialog = false
-                        onBack()
+                        viewModel.deleteNote(target.id)
+                        deleteTarget = null
+                        if (target.id == focusedNote?.id) onBack()
                     },
                     colors = ButtonDefaults.textButtonColors(contentColor = LikeRed),
                 ) { Text("Delete") }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel", color = SecondaryText) }
+                TextButton(onClick = { deleteTarget = null }) { Text("Cancel", color = SecondaryText) }
             },
             containerColor = SecondaryGroupedBg,
         )
     }
 
     // Block confirmation dialog
-    if (showBlockDialog && focusedNote != null) {
+    blockTarget?.let { target ->
         AlertDialog(
-            onDismissRequest = { showBlockDialog = false },
+            onDismissRequest = { blockTarget = null },
             title = { Text("Block User", color = PrimaryText) },
             text = { Text("Block this user? Their posts will be hidden from your feed.", color = SecondaryText) },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        viewModel.blockUser(focusedNote!!.pubkey)
-                        showBlockDialog = false
-                        onBack()
+                        viewModel.blockUser(target.pubkey)
+                        blockTarget = null
+                        if (target.id == focusedNote?.id) onBack()
                     },
                     colors = ButtonDefaults.textButtonColors(contentColor = LikeRed),
                 ) { Text("Block") }
             },
             dismissButton = {
-                TextButton(onClick = { showBlockDialog = false }) { Text("Cancel", color = SecondaryText) }
+                TextButton(onClick = { blockTarget = null }) { Text("Cancel", color = SecondaryText) }
             },
             containerColor = SecondaryGroupedBg,
         )
     }
 
     // Report content dialog (NIP-56 reason picker + auto-block)
-    if (showReportDialog && focusedNote != null) {
+    reportTarget?.let { target ->
         UGCReportDialog(
             onReport = { reason, description ->
-                viewModel.reportNote(focusedNote!!.effectiveEventId, focusedNote!!.pubkey, reason, description)
-                showReportDialog = false
-                onBack()
+                viewModel.reportNote(target.effectiveEventId, target.pubkey, reason, description)
+                reportTarget = null
+                if (target.id == focusedNote?.id) onBack()
             },
-            onDismiss = { showReportDialog = false },
+            onDismiss = { reportTarget = null },
         )
     }
 
@@ -750,6 +753,10 @@ fun NoteDetailScreen(
                                 onZap = { zapTargetNote = parent },
                                 onShare = { shareNote(parent) },
                                 onBroadcast = { broadcastTargetNote = parent },
+                                isOwnNote = viewModel.isOwnNote(parent.pubkey),
+                                onReport = { reportTarget = parent },
+                                onBlock = { blockTarget = parent },
+                                onDelete = { deleteTarget = parent },
                                 onLongPressLike = { emojiTargetNote = parent },
                             )
                         }
@@ -785,9 +792,9 @@ fun NoteDetailScreen(
                         onReply = { onReply(focusedNote!!.effectiveEventId) },
                         onFollow = { viewModel.followUser(focusedNote!!.pubkey) },
                         onUnfollow = { viewModel.unfollowUser(focusedNote!!.pubkey) },
-                        onBlock = { showBlockDialog = true },
-                        onDelete = { showDeleteDialog = true },
-                        onReport = { showReportDialog = true },
+                        onBlock = { blockTarget = focusedNote },
+                        onDelete = { deleteTarget = focusedNote },
+                        onReport = { reportTarget = focusedNote },
                         onReactionsClick = { showReactorsSheet = true },
                         onRepostsClick = { showRepostersSheet = true },
                         onZapsClick = { showZappersSheet = true },
@@ -847,6 +854,13 @@ fun NoteDetailScreen(
                         onZapNote = { zapTargetNote = it },
                         onShareNote = { shareNote(it) },
                         onBroadcastNote = { broadcastTargetNote = it },
+                        onModerateNote = { note, action ->
+                            when (action) {
+                                Moderation.REPORT -> reportTarget = note
+                                Moderation.BLOCK -> blockTarget = note
+                                Moderation.DELETE -> deleteTarget = note
+                            }
+                        },
                         onLongPressLikeNote = { emojiTargetNote = it },
                     )
                 }
@@ -1054,6 +1068,13 @@ private fun CompactParentRow(
 // Matches iOS ThreadedReplyNode: recursive tree rendering with depth-based
 // collapsing, compact/full modes, focus highlight, and thread connector lines.
 
+/**
+ * What a reply's overflow menu asked for. One parameter through the recursive
+ * reply tree instead of three, and the confirmation dialogs stay at screen
+ * level where they already are.
+ */
+internal enum class Moderation { REPORT, BLOCK, DELETE }
+
 private const val MAX_INDENT_DEPTH = 5
 private const val COLLAPSE_DEPTH = 3
 
@@ -1078,6 +1099,7 @@ private fun ThreadedReplyNode(
     onZapNote: (FeedNote) -> Unit,
     onShareNote: (FeedNote) -> Unit,
     onBroadcastNote: (FeedNote) -> Unit,
+    onModerateNote: (FeedNote, Moderation) -> Unit,
     onLongPressLikeNote: (FeedNote) -> Unit,
 ) {
     // Keyed on the reply list too: late-arriving replies (refocus fetch,
@@ -1131,6 +1153,7 @@ private fun ThreadedReplyNode(
                             onZapNote = onZapNote,
                             onShareNote = onShareNote,
                             onBroadcastNote = onBroadcastNote,
+                            onModerateNote = onModerateNote,
                             onLongPressLikeNote = onLongPressLikeNote,
                         )
                         Spacer(Modifier.height(6.dp))
@@ -1157,6 +1180,10 @@ private fun ThreadedReplyNode(
                 onZap = { onZapNote(reply) },
                 onShare = { onShareNote(reply) },
                 onBroadcast = { onBroadcastNote(reply) },
+                isOwnNote = viewModel.isOwnNote(reply.pubkey),
+                onReport = { onModerateNote(reply, Moderation.REPORT) },
+                onBlock = { onModerateNote(reply, Moderation.BLOCK) },
+                onDelete = { onModerateNote(reply, Moderation.DELETE) },
                 onLongPressLike = { onLongPressLikeNote(reply) },
             )
 
@@ -1261,6 +1288,7 @@ private fun ThreadedReplyNode(
                                     onZapNote = onZapNote,
                                     onShareNote = onShareNote,
                                     onBroadcastNote = onBroadcastNote,
+                                    onModerateNote = onModerateNote,
                                     onLongPressLikeNote = onLongPressLikeNote,
                                 )
                             }
@@ -1352,47 +1380,30 @@ private fun HeroNoteCard(
                     }
                 }
 
-                // More menu button
+                // More menu button. Same component as every other note's menu —
+                // this one carries Follow/Unfollow as well, because the focused
+                // note is the only place that offers them.
                 Box {
                     IconButton(onClick = { showMoreMenu = true }) {
                         Icon(NostrVaultIcons.More, "More", tint = SecondaryText)
                     }
-                    DropdownMenu(
+                    NoteActionsMenu(
                         expanded = showMoreMenu,
-                        onDismissRequest = { showMoreMenu = false },
-                    ) {
-                        if (isOwnNote) {
-                            DropdownMenuItem(
-                                text = { Text("Delete Post", color = LikeRed) },
-                                onClick = { showMoreMenu = false; onDelete() },
-                                leadingIcon = { Icon(NostrVaultIcons.Delete, null, tint = LikeRed) },
-                            )
-                        } else {
-                            if (isFollowing) {
-                                DropdownMenuItem(
-                                    text = { Text("Unfollow") },
-                                    onClick = { showMoreMenu = false; onUnfollow() },
-                                    leadingIcon = { Icon(NostrVaultIcons.Blocked, null, tint = ZapOrange) },
-                                )
+                        actions = buildList {
+                            if (isOwnNote) {
+                                add(NoteAction(NostrVaultIcons.Delete, "Delete Post", destructive = true, onClick = onDelete))
                             } else {
-                                DropdownMenuItem(
-                                    text = { Text("Follow") },
-                                    onClick = { showMoreMenu = false; onFollow() },
-                                    leadingIcon = { Icon(NostrVaultIcons.PersonAdd, null, tint = RepostGreen) },
-                                )
+                                if (isFollowing) {
+                                    add(NoteAction(NostrVaultIcons.Blocked, "Unfollow", onClick = onUnfollow))
+                                } else {
+                                    add(NoteAction(NostrVaultIcons.PersonAdd, "Follow", onClick = onFollow))
+                                }
+                                add(NoteAction(NostrVaultIcons.Blocked, "Block", destructive = true, onClick = onBlock))
+                                add(NoteAction(NostrVaultIcons.Alert, "Report", destructive = true, onClick = onReport))
                             }
-                            DropdownMenuItem(
-                                text = { Text("Block", color = LikeRed) },
-                                onClick = { showMoreMenu = false; onBlock() },
-                                leadingIcon = { Icon(NostrVaultIcons.Blocked, null, tint = LikeRed) },
-                            )
-                            DropdownMenuItem(
-                                text = { Text("Report", color = LikeRed) },
-                                onClick = { showMoreMenu = false; onReport() },
-                                leadingIcon = { Icon(NostrVaultIcons.Alert, null, tint = LikeRed) },
-                            )
-                        }
-                    }
+                        },
+                        onDismiss = { showMoreMenu = false },
+                    )
                 }
             }
 

--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/feed/FeedScreen.kt
@@ -174,7 +174,6 @@ fun FeedScreen(
 
     // More menu / delete confirmation state
     var deleteNoteId by remember { mutableStateOf<String?>(null) }
-    var moreMenuNoteId by remember { mutableStateOf<String?>(null) }
     var reportNoteId by remember { mutableStateOf<String?>(null) }
     var blockNoteId by remember { mutableStateOf<String?>(null) }
 
@@ -533,7 +532,10 @@ fun FeedScreen(
                                 // menu at all, so reporting and blocking were only
                                 // reachable two navigations deep — from the note
                                 // screen, which you have to open the content to see.
-                                onMore = { id -> moreMenuNoteId = id },
+                                isOwnNote = viewModel.isOwnNote(note.pubkey),
+                                onReport = { reportNoteId = note.id },
+                                onBlock = { blockNoteId = note.id },
+                                onDelete = { deleteNoteId = note.id },
                                 onLongPressLike = { id -> emojiPickerNoteId = id },
                                 modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
                             )
@@ -588,80 +590,6 @@ fun FeedScreen(
             onZap = { amount ->
                 zapNoteId?.let { viewModel.zapNote(it, amount) }
                 zapNoteId = null
-            },
-        )
-    }
-
-    // More menu dropdown
-    if (moreMenuNoteId != null) {
-        val targetNote = notes.find { it.id == moreMenuNoteId || it.effectiveEventId == moreMenuNoteId }
-        val isOwn = targetNote != null && viewModel.isOwnNote(targetNote.pubkey)
-
-        AlertDialog(
-            onDismissRequest = { moreMenuNoteId = null },
-            title = { Text("Actions") },
-            text = {
-                Column {
-                    if (isOwn) {
-                        FeedActionRow(
-                            icon = NostrVaultIcons.Delete,
-                            label = "Delete Post",
-                            tint = ErrorRed,
-                            onClick = {
-                                deleteNoteId = moreMenuNoteId
-                                moreMenuNoteId = null
-                            },
-                        )
-                    } else {
-                        FeedActionRow(
-                            icon = NostrVaultIcons.Alert,
-                            label = "Report",
-                            tint = ErrorRed,
-                            onClick = {
-                                reportNoteId = moreMenuNoteId
-                                moreMenuNoteId = null
-                            },
-                        )
-                        FeedActionRow(
-                            icon = NostrVaultIcons.Blocked,
-                            label = "Block",
-                            tint = ErrorRed,
-                            onClick = {
-                                blockNoteId = moreMenuNoteId
-                                moreMenuNoteId = null
-                            },
-                        )
-                    }
-                    // Copy link is offered for any note, yours included.
-                    if (targetNote != null) {
-                        FeedActionRow(
-                            icon = NostrVaultIcons.Share,
-                            label = "Copy link",
-                            tint = PrimaryText,
-                            onClick = {
-                                val nevent = HavenBridge.encodeNevent(
-                                    targetNote.effectiveEventId,
-                                    targetNote.pubkey,
-                                    targetNote.kind,
-                                ) ?: HavenBridge.hexToNote1(targetNote.effectiveEventId)
-                                ?: targetNote.effectiveEventId
-                                clipboard.setText(AnnotatedString(threadLink(nevent)))
-                                Toast.makeText(context, "Link copied", Toast.LENGTH_SHORT).show()
-                                moreMenuNoteId = null
-                            },
-                        )
-                    }
-                }
-            },
-            // Cancel is the dismiss action, so it belongs in the dismiss slot.
-            // In `confirmButton` it took the emphasised position, which reads as
-            // "this is the thing to do" on a menu whose real items are
-            // destructive.
-            confirmButton = {},
-            dismissButton = {
-                TextButton(onClick = { moreMenuNoteId = null }) {
-                    Text("Cancel")
-                }
             },
         )
     }
@@ -1435,30 +1363,4 @@ private fun List<String>.resolveAgainst(
     val resolved = HashMap<String, FeedProfile>(size)
     for (pubkey in this) profiles[pubkey]?.let { resolved[pubkey] = it }
     return resolved
-}
-
-/**
- * One row of the feed's Actions dialog.
- *
- * Extracted because the dialog now has four of these and they were being
- * hand-assembled — icon, spacer, coloured label — which is exactly how the
- * variants drift apart.
- */
-@Composable
-private fun FeedActionRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-    tint: androidx.compose.ui.graphics.Color,
-    onClick: () -> Unit,
-) {
-    TextButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(18.dp))
-            Spacer(Modifier.width(8.dp))
-            Text(label, color = tint)
-        }
-    }
 }


### PR DESCRIPTION
Prerequisite for #25. Based on `android/feed-moderation` (#26), not on master — #26 merges independently, this stacks on it.

## Why

There were two overflow menus and they were about to become three.

- `NoteDetailScreen` — anchored `DropdownMenu` on the focused note (Follow/Unfollow/Block/Report/Delete).
- `FeedScreen` — an `AlertDialog`, under a comment calling it a dropdown, driven by a screen-level `moreMenuNoteId` and a `notes.find {}`.
- Replies — neither. You could report a note from the feed but not from the thread you opened it in.

#25 moves Share and Broadcast off the action row and into that menu, which is only safe once every note that loses a button has one.

## What

**`NoteActionsMenu`** owns the presentation: anchored `DropdownMenu`, one row shape, destructive items tinted from one place. The item *set* stays a parameter, because it legitimately differs by surface — the focused note can follow and unfollow its author, a search result can only copy a link.

The anchored menu is the survivor rather than the dialog. It is Material's overflow affordance and it keeps the connection to the note you tapped; a modal dialog loses that anchor, which is why its Cancel had drifted into `confirmButton`.

**`NoteCard.onMore` is gone.** The card builds its own item list from nullable handlers (`isOwnNote`, `onReport`, `onBlock`, `onDelete`) and anchors the menu to its own button. Copy link needs nothing from the caller and is always offered, so every card has a menu — `SearchScreen` gets one item, the feed gets three. Copy link also stops being a third hand-assembly of `encodeNevent` + `threadLink` + clipboard + toast.

**`NoteDetailScreen`'s confirmations hold a note, not a flag.** `showDeleteDialog: Boolean` → `deleteTarget: FeedNote?`, same for block and report. The menu is now on every note on that screen, and the old dialogs all called `onBack()` unconditionally — correct for the focused note, wrong for a reply. Now: acting on the focused note still leaves the screen, acting on a reply does not. The recursive reply tree carries one `onModerateNote(note, Moderation)` parameter instead of three.

## Verification

`:app:compileReleaseKotlin` and `:app:testReleaseUnitTest` both BUILD SUCCESSFUL in a worktree at this SHA.

**Not device-verified** — no Android device attached to this Mac. What wants eyes on hardware: the menu anchors under the button on a card near the bottom of the feed, and Delete on a reply leaves you in the thread instead of backing out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)