### PR TITLE
fix(macos): give every swipe- and touch-only control a pointer and keyboard path

### DIFF
--- a/HavenApp/HavenApp/Localizable.xcstrings
+++ b/HavenApp/HavenApp/Localizable.xcstrings
@@ -605,6 +605,16 @@
         }
       }
     },
+    "dm.inbox.refresh" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
+          }
+        }
+      }
+    },
     "dm.inbox.title" : {
       "localizations" : {
         "en" : {

--- a/HavenApp/HavenApp/Views/DMInboxView.swift
+++ b/HavenApp/HavenApp/Views/DMInboxView.swift
@@ -97,9 +97,26 @@ struct DMInboxView: View {
             }
             #else
             .toolbar {
+                // The sheet has no title bar and macOS has no swipe-to-dismiss: without
+                // this the inbox could only be closed by quitting the window.
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "dm.inbox.close")) { dismiss() }
+                        .keyboardShortcut(.cancelAction)
+                }
                 ToolbarItem(placement: .automatic) {
                     HStack(spacing: 12) {
                         if selectedTab == .dms {
+                            // macOS has no pull-to-refresh, so `.refreshable` on the
+                            // conversation list was a refresh path with no pointer or
+                            // keyboard way to reach it.
+                            Button(action: { dmService.refresh() }) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.appSystem(size: 15, weight: .semibold))
+                                    .foregroundColor(.havenPurple)
+                            }
+                            .help(String(localized: "dm.inbox.refresh"))
+                            .keyboardShortcut("r", modifiers: .command)
+
                             Button(action: { dmService.markAllAsRead() }) {
                                 Image(systemName: "checkmark.circle")
                                     .font(.appSystem(size: 15, weight: .semibold))

--- a/HavenApp/HavenApp/Views/DMThreadView.swift
+++ b/HavenApp/HavenApp/Views/DMThreadView.swift
@@ -113,6 +113,13 @@ struct DMThreadView: View {
                             .textFieldStyle(.plain)
                             .lineLimit(1...5)
                             .font(.appSystem(size: 15))
+                            #if os(macOS)
+                            // Return sends, the way every desktop chat client does.
+                            // Nothing is lost by taking the key: a vertical-axis
+                            // TextField on macOS ignores plain Return anyway — Option
+                            // + Return is what inserts a newline, and still does.
+                            .onSubmit { sendMessage() }
+                            #endif
                             .padding(.horizontal, 16)
                             .padding(.vertical, 10)
                             .background(Color.platformSecondaryGroupedBackground)
@@ -156,6 +163,16 @@ struct DMThreadView: View {
             .navigationTitle(counterpartyProfile?.bestName ?? "DM")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #else
+            // Presented as a sheet from the profile, where there is no title bar and no
+            // swipe-down: Escape or this button is the only way back out. Pushed from the
+            // inbox, the same dismiss pops the thread.
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(String(localized: "dm.inbox.close")) { dismiss() }
+                        .keyboardShortcut(.cancelAction)
+                }
+            }
             #endif
             .alert("Failed to Send", isPresented: Binding<Bool>(
                 get: { sendError != nil },

--- a/HavenApp/HavenApp/Views/FollowingBackupView.swift
+++ b/HavenApp/HavenApp/Views/FollowingBackupView.swift
@@ -123,6 +123,17 @@ struct FollowingBackupSettingsView: View {
                         NavigationLink(destination: SnapshotDetailView(snapshot: snapshot, isActiveAccount: isViewingActiveAccount)) {
                             snapshotRow(snapshot)
                         }
+                        #if os(macOS)
+                        // `.onDelete` below is swipe-only, and macOS rows don't swipe:
+                        // right-click is the platform's delete affordance here.
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                backupService.deleteSnapshot(id: snapshot.id, forAccountKey: selectedSnapshotKey)
+                            } label: {
+                                Label("Delete Snapshot", systemImage: "trash")
+                            }
+                        }
+                        #endif
                     }
                     .onDelete { offsets in
                         deleteSnapshots(at: offsets)

--- a/HavenApp/HavenApp/Views/GroupChatView.swift
+++ b/HavenApp/HavenApp/Views/GroupChatView.swift
@@ -70,6 +70,12 @@ struct GroupChatView: View {
                         .textFieldStyle(.plain)
                         .lineLimit(1...5)
                         .font(.appSystem(size: 15))
+                        #if os(macOS)
+                        // Return sends. See the note in DMThreadView: plain Return is
+                        // free to take here because the field never inserted a newline
+                        // for it on macOS; Option + Return still does.
+                        .onSubmit { sendMessage() }
+                        #endif
                         .padding(.horizontal, 16)
                         .padding(.vertical, 10)
                         .background(Color.platformSecondaryGroupedBackground)

--- a/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryView.swift
+++ b/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryView.swift
@@ -381,6 +381,17 @@ struct MediaGalleryView: View {
 
                 Spacer()
 
+                // The gallery's only refresh was `.refreshable`, which macOS never
+                // surfaces — this is the pointer and ⌘R path to the same call.
+                IconFilterButton(
+                    icon: "arrow.clockwise",
+                    tooltip: "Refresh Media",
+                    isSelected: true,
+                    color: .havenPurple,
+                    action: { refreshAll() }
+                )
+                .keyboardShortcut("r", modifiers: .command)
+
                 sortMenu
 
                 desktopUploadMenu

--- a/HavenApp/HavenApp/Views/MediaPagerView.swift
+++ b/HavenApp/HavenApp/Views/MediaPagerView.swift
@@ -68,7 +68,15 @@ struct MediaPagerView<Item: Hashable, ItemContent: View>: View {
 
     var body: some View {
         pagerBody
+            #if os(iOS)
+            // iOS propagates a container value down onto the page content, which is a
+            // reasonable place for the position. macOS drops `value` on AXGroup/AXUnknown
+            // and propagates it onto every child element instead — verified with an
+            // AXUIElement probe, where both arrow buttons ended up announcing
+            // "Image 1 of 3" and no element carried the pager's own position. There the
+            // position lives in the dots' *label*; see `pageDots`.
             .accessibilityValue(items.isEmpty ? "" : "Image \((index ?? 0) + 1) of \(items.count)")
+            #endif
             .onAppear { syncIndexOnAppear() }
             .onChange(of: items) { _, newItems in reconcile(after: newItems) }
     }
@@ -191,7 +199,11 @@ private struct MacMediaPager<Item: Hashable, ItemContent: View>: View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.white)
+                // Dimming the whole control also dimmed the scrim, which took the
+                // disabled arrow to 1.6:1 over a bright image — and page 0 is the first
+                // frame a macOS user sees, so half the affordance was invisible in it.
+                // Only the glyph dims now; the scrim stays at full strength below.
+                .foregroundColor(.white.opacity(enabled ? 1 : 0.55))
                 .frame(width: 28, height: 28)
                 // 0.7 opacity black over a worst-case bright (L≈0.9) image composites to an
                 // effective background luminance of 0.9*(1-0.7) = 0.27; against a white
@@ -201,7 +213,6 @@ private struct MacMediaPager<Item: Hashable, ItemContent: View>: View {
                 .overlay(Circle().stroke(Color.borderHairline, lineWidth: 0.5))
         }
         .buttonStyle(.plain)
-        .opacity(enabled ? 1 : 0.35)
         .disabled(!enabled)
         .animation(Motion.chrome, value: enabled)
         .accessibilityLabel(accessibilityLabel)
@@ -217,13 +228,17 @@ private struct MacMediaPager<Item: Hashable, ItemContent: View>: View {
                     // even when the fill alone would wash out over a bright photo.
                     .overlay(Circle().stroke(Color.white.opacity(isCurrent ? 0 : 0.9), lineWidth: 0.5))
                     .frame(width: isCurrent ? 6 : 5, height: isCurrent ? 6 : 5)
-                    .accessibilityHidden(true)
             }
         }
         .animation(Motion.pick, value: index)
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
         .background(Capsule().fill(Color.black.opacity(0.7)))
+        // One element for the whole row, carrying the position as its label: a row of
+        // circles read one at a time is noise, and macOS AX drops `value` on a group, so
+        // the label is the only field that survives here.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Image \((index ?? 0) + 1) of \(items.count)")
     }
 }
 #endif

--- a/HavenApp/HavenApp/Views/ProfileView.swift
+++ b/HavenApp/HavenApp/Views/ProfileView.swift
@@ -260,11 +260,19 @@ struct ProfileView: View {
                         NoteDetailView(note: detailNote)
                     }
             }
+            #if os(macOS)
+            .frame(minWidth: 520, minHeight: 560)
+            #endif
         }
         .sheet(item: $showingProfileKey) { p in
             ProfileView(pubkey: p.id, onDismiss: { showingProfileKey = nil })
                 .environmentObject(nostrService)
                 .environmentObject(configService)
+                #if os(macOS)
+                // A macOS sheet with no minimum inherits its content's ideal size and can
+                // open too small to use.
+                .frame(minWidth: 520, minHeight: 560)
+                #endif
         }
         .sheet(item: $showingMediaUrl) { media in
             FeedMediaPager(urls: media.allURLs, selected: media.url, onDismiss: { showingMediaUrl = nil })
@@ -411,6 +419,18 @@ struct ProfileView: View {
         }
         #else
         .toolbar {
+            ToolbarItem(placement: .automatic) {
+                if isOwnProfile {
+                    // `.refreshable` on the scroll view is the profile's only refresh
+                    // path, and macOS has no pull-to-refresh to reach it.
+                    Button(action: { Task { await refreshProfile() } }) {
+                        Image(systemName: "arrow.clockwise")
+                            .foregroundColor(.havenPurple)
+                    }
+                    .help("Refresh Profile")
+                    .keyboardShortcut("r", modifiers: .command)
+                }
+            }
             ToolbarItem(placement: .automatic) {
                 if isOwnerProfile {
                     Button(action: { showingLightning = true }) {

--- a/HavenApp/HavenApp/Views/Search/SearchView.swift
+++ b/HavenApp/HavenApp/Views/Search/SearchView.swift
@@ -23,9 +23,7 @@ struct SearchView: View {
     @State private var cachedTrending: [String] = []
     @State private var cachedSuggested: [(String, FeedProfile)] = []
     @State private var lastDiscoveryRefresh: Date = .distantPast
-    #if os(iOS)
     @FocusState private var searchFieldFocused: Bool
-    #endif
 
     enum SearchMode: CaseIterable {
         case relay, global
@@ -153,10 +151,19 @@ struct SearchView: View {
                         TextField("Search users, notes, hashtags...", text: $searchQuery)
                             .textFieldStyle(.plain)
                             .font(.appSystem(size: 14))
-                            #if os(iOS)
                             .focused($searchFieldFocused)
+                            #if os(iOS)
                             .submitLabel(.search)
                             .onSubmit { searchFieldFocused = false }
+                            #else
+                            // Return searches immediately instead of waiting out the
+                            // 300ms debounce; Escape clears the field and the results.
+                            .onSubmit { searchNow() }
+                            .onKeyPress(.escape) {
+                                guard !searchQuery.isEmpty else { return .ignored }
+                                clearSearch()
+                                return .handled
+                            }
                             #endif
                             .onChange(of: searchQuery) { _, query in
                                 searchDebounceTask?.cancel()
@@ -179,9 +186,7 @@ struct SearchView: View {
 
                         if !searchQuery.isEmpty {
                             Button(action: {
-                                searchQuery = ""
-                                resultTypeFilter = .all
-                                nostrService.cancelGlobalSearch()
+                                clearSearch()
                                 #if os(iOS)
                                 searchFieldFocused = false
                                 #endif
@@ -358,6 +363,11 @@ struct SearchView: View {
             ProfileView(pubkey: profile.id, onDismiss: { showingProfile = nil })
                 .environmentObject(nostrService)
                 .environmentObject(configService)
+                #if os(macOS)
+                // Without a minimum, a macOS sheet takes its content's ideal size, which
+                // for a profile is small enough to be unusable.
+                .frame(minWidth: 520, minHeight: 560)
+                #endif
         }
         .sheet(item: $showingNoteDetail) { note in
             NavigationStack {
@@ -366,12 +376,20 @@ struct SearchView: View {
                         NoteDetailView(note: detailNote)
                     }
             }
+            #if os(macOS)
+            .frame(minWidth: 520, minHeight: 560)
+            #endif
         }
         .sheet(item: $showingMediaUrl) { media in
             FeedMediaPager(urls: media.allURLs, selected: media.url, onDismiss: { showingMediaUrl = nil })
         }
         .onAppear {
             refreshDiscovery(force: true)
+            #if os(macOS)
+            // No tap-to-focus convention on the desktop: the field a window opens
+            // on should already be taking keystrokes.
+            searchFieldFocused = true
+            #endif
         }
         .onReceive(feedService.$notes) { notes in
             // Throttled refresh of the empty-state discovery lists as the feed grows.
@@ -731,6 +749,10 @@ struct SearchView: View {
 
     @ViewBuilder
     private func hashtagRow(hashtag: String) -> some View {
+        Button(action: {
+            searchQuery = "#\(hashtag)"
+            searchNow()
+        }) {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 Text("#\(hashtag)")
@@ -748,10 +770,16 @@ struct SearchView: View {
         .padding(.vertical, 8)
         .background(Color.secondary.opacity(0.05))
         .cornerRadius(8)
+        .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     @ViewBuilder
     private func linkRow(link: SearchLink) -> some View {
+        // A link result looks tappable (purple title, boxed row) and was inert on both
+        // platforms. Rows whose URL doesn't parse stay inert rather than pretending.
+        conditionalLink(url: URL(string: link.url)) {
         VStack(alignment: .leading, spacing: 4) {
             Text(link.title)
                 .font(.appSystem(size: 13, weight: .semibold))
@@ -768,6 +796,18 @@ struct SearchView: View {
         .padding(.vertical, 8)
         .background(Color.secondary.opacity(0.05))
         .cornerRadius(8)
+        .contentShape(Rectangle())
+        }
+    }
+
+    @ViewBuilder
+    private func conditionalLink<Content: View>(url: URL?, @ViewBuilder content: () -> Content) -> some View {
+        if let url {
+            Link(destination: url) { content() }
+                .buttonStyle(.plain)
+        } else {
+            content()
+        }
     }
 
     private func decodeNostrNoteId(_ query: String) -> String? {
@@ -826,6 +866,26 @@ struct SearchView: View {
             return
         }
         performSearch(query: searchQuery)
+    }
+
+    /// Runs the search for whatever is in the field right now, cancelling the debounce
+    /// task so Return doesn't race a second search behind it.
+    private func searchNow() {
+        searchDebounceTask?.cancel()
+        let trimmed = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        performSearch(query: searchQuery)
+        saveRecentSearch(searchQuery)
+    }
+
+    private func clearSearch() {
+        searchDebounceTask?.cancel()
+        searchQuery = ""
+        resultTypeFilter = .all
+        searchResults = .empty
+        pendingDirectNoteId = nil
+        isSearching = false
+        nostrService.cancelGlobalSearch()
     }
 
     private func performSearch(query: String) {

--- a/HavenApp/HavenApp/Views/SettingsView.swift
+++ b/HavenApp/HavenApp/Views/SettingsView.swift
@@ -681,7 +681,11 @@ struct AccountsSettingsView: View {
             } header: {
                 Text("Accounts")
             } footer: {
+                #if os(iOS)
                 Text("Each account can hold both a local key and a remote signer. Tap to manage signing. Swipe to remove.")
+                #else
+                Text("Each account can hold both a local key and a remote signer. Click to manage signing, or to remove the account.")
+                #endif
             }
 
             Section {
@@ -1190,6 +1194,7 @@ struct ConnectSignerSheetView: View {
                 Button("Cancel") { performDismiss() }
                     .buttonStyle(.plain)
                     .foregroundColor(.secondary)
+                    .keyboardShortcut(.cancelAction)
                 Spacer()
                 Text("Connect Remote Signer")
                     .font(.appHeadline)
@@ -1198,6 +1203,7 @@ struct ConnectSignerSheetView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(Color.havenPurple)
                     .disabled(bunkerURI.isEmpty || isConnecting)
+                    .keyboardShortcut(.defaultAction)
             }
             .padding()
 
@@ -1366,6 +1372,7 @@ struct AddAccountSheetView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.secondary)
+                .keyboardShortcut(.cancelAction)
                 
                 Spacer()
                 
@@ -1380,6 +1387,7 @@ struct AddAccountSheetView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(Color.havenPurple)
                 .disabled(addInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .keyboardShortcut(.defaultAction)
             }
             .padding()
             .background(Color.platformControlBackground.opacity(0.5))
@@ -1472,6 +1480,7 @@ struct ImportKeySheetView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.secondary)
+                .keyboardShortcut(.cancelAction)
                 
                 Spacer()
                 
@@ -1486,6 +1495,7 @@ struct ImportKeySheetView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(Color.havenPurple)
                 .disabled(importNsec.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || importPassword.isEmpty || importConfirm.isEmpty)
+                .keyboardShortcut(.defaultAction)
             }
             .padding()
             .background(Color.platformControlBackground.opacity(0.5))
@@ -1626,6 +1636,7 @@ struct RevealKeySheetView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.secondary)
+                .keyboardShortcut(.cancelAction)
 
                 Spacer()
 
@@ -1641,12 +1652,14 @@ struct RevealKeySheetView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(Color.havenPurple)
                     .disabled(password.isEmpty)
+                    .keyboardShortcut(.defaultAction)
                 } else {
                     Button("Done") {
                         performDismiss()
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(Color.havenPurple)
+                    .keyboardShortcut(.defaultAction)
                 }
             }
             .padding()

--- a/HavenApp/HavenApp/Views/UGCReportingDialog.swift
+++ b/HavenApp/HavenApp/Views/UGCReportingDialog.swift
@@ -97,30 +97,39 @@ public struct UGCReportingDialog: View {
     
     private var footer: some View {
         HStack(spacing: 16) {
-            Button("Cancel") {
-                performDismiss()
+            // Padding and background belong inside the label: applied to the Button they
+            // only decorate it, and the click target stays the width of the glyphs.
+            Button(action: { performDismiss() }) {
+                Text("Cancel")
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    .background(Color.secondary.opacity(0.1))
+                    .cornerRadius(8)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
-            .background(Color.secondary.opacity(0.1))
-            .cornerRadius(8)
-            
+            .keyboardShortcut(.cancelAction)
+
             Button(action: performReport) {
-                if isReporting {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    Text("Report & Block")
+                Group {
+                    if isReporting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Report & Block")
+                    }
                 }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 10)
+                .background(Color.red.opacity(0.8))
+                .foregroundColor(.white)
+                .cornerRadius(8)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(isReporting)
-            .padding(.horizontal, 24)
-            .padding(.vertical, 10)
-            .background(Color.red.opacity(0.8))
-            .foregroundColor(.white)
-            .cornerRadius(8)
+            // Deliberately not `.defaultAction`: Return firing an irreversible
+            // report-and-block is the wrong thing to make the easiest key to hit.
         }
         .padding()
         .background(Color.secondary.opacity(0.05))

--- a/HavenApp/HavenApp/Views/Vault/VaultView.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultView.swift
@@ -566,6 +566,8 @@ struct VaultView: View {
 
                 Spacer()
 
+                refreshButton
+
                 if viewMode == .notes {
                     filterView
                 } else if viewMode == .likes {
@@ -586,6 +588,23 @@ struct VaultView: View {
         .background(Color.platformSecondaryGroupedBackground)
     }
 
+    // MARK: - Refresh
+
+    /// `.refreshable` is the vault's only refresh path and macOS has no pull-to-refresh,
+    /// so without this the list could only be refreshed by switching accounts or
+    /// restarting the relay.
+    @ViewBuilder
+    var refreshButton: some View {
+        IconFilterButton(
+            icon: "arrow.clockwise",
+            tooltip: "Refresh Vault",
+            isSelected: true,
+            color: .havenPurple,
+            action: { refreshAll(.incremental) }
+        )
+        .keyboardShortcut("r", modifiers: .command)
+    }
+
     // MARK: - Header View
 
     @ViewBuilder
@@ -597,6 +616,7 @@ struct VaultView: View {
                     HStack {
                         modeView
                         Spacer()
+                        refreshButton
                         searchToggleButton
                     }
                     if viewMode == .notes {
@@ -626,6 +646,7 @@ struct VaultView: View {
                         } else if viewMode == .zaps {
                             zapsFilterView
                         }
+                        refreshButton
                         searchToggleButton
                         compactToggleButton
                     }


### PR DESCRIPTION
Closes the macOS pointer/keyboard sweep (issue `f249132d`). Picked up from Tal, who had the issue but hadn't pushed anything.

## What was unreachable, and what it is now

**Keyboard**
- Search now takes focus on appear, Return searches immediately (cancelling the 300ms debounce rather than racing it), Escape clears the field and the results.
- Both chat composers send on Return (`DMThreadView`, `GroupChatView`).
- The four macOS Settings sheets — Add Account, Import Key, Reveal Key, Connect Signer — declare `.cancelAction` / `.defaultAction`, so Escape and Return work.
- The report dialog gets Escape only. Return firing an irreversible report-and-block is the wrong thing to make the easiest key to hit.

**No way out**
- The DM inbox and DM thread sheets get a Close control bound to Escape. Neither had any dismiss affordance on macOS — the inbox could only be closed by closing the window.

**Swipe-only / pull-only**
- Following-list snapshots get a right-click Delete. `.onDelete` was the only delete path, and macOS rows don't swipe.
- Explicit **Refresh (⌘R)** in the vault header (both wide and narrow macOS layouts), the media gallery header, the profile toolbar, and the DM inbox toolbar. `.refreshable` was the only refresh path in all four.
- **Accounts already had a pointer path** and I left it alone: the row opens a detail sheet with a confirmed *Remove Account*, under the same non-owner restriction as the swipe's `index > 0` guard. Adding a bare swipe-equivalent would have bypassed that confirmation. Only the footer copy changed — "Swipe to remove" is false on macOS.

**Not clickable where they look it**
- Hashtag results search the tag; link results open the URL. Rows whose URL doesn't parse stay inert rather than pretending to be a link.
- The report dialog's *Cancel* and *Report & Block* had their padding and background applied to the `Button` instead of to the label, so only the text glyphs were clickable. Moved inside the label + `.contentShape`.
- Profile and note-detail sheets opened from search and from the profile get macOS minimum sizes; without one a sheet takes its content's ideal size and can open too small to use.

## Folded in from the PR #28 review

- **Pager position moves into the dots' accessibility label on macOS.** The container `.accessibilityValue` propagated onto *both arrow buttons* with no element carrying the pager's own position. iOS keeps the container value, where it does propagate to the page content.
- **Disabled arrow contrast.** Dimming the whole control dimmed the scrim too, measuring 1.6:1 against a bright image at page 0 — the first frame a macOS user sees. Only the glyph dims now.

## Verification

- `-scheme HavenApp` Debug and `-scheme HavenApp-iOS` Debug (generic iOS Simulator) both **BUILD SUCCEEDED** at this commit's tree.
- `just check-project` clean (230 paths, per-target phases agree). No `project.yml`/`.xcodeproj` change.
- New string-catalogue key resolves in the **built** bundle: `plutil -p "Nostr Vault.app/Contents/Resources/en.lproj/Localizable.strings"` shows `"dm.inbox.refresh" => "Refresh"`.
- **Return-to-send is measured, not assumed.** A `swiftc` harness posting synthetic `NSEvent` keyDowns through the real responder chain into a hosted vertical-axis `TextField`:
  - `.onSubmit` fires on plain Return (and on Shift+Return);
  - with no handler at all, plain Return and Shift+Return insert **nothing** — only Option+Return inserts a newline. So Return was free to take, and the newline path is unchanged.
  - `.onKeyPress(.escape)` fires while the field holds focus, which is what the search Escape relies on.
- **AX probe** (`NSHostingView` + `AXUIElementCreateApplication(getpid())`) on the changed pager chrome:

```
AXGroup
  AXButton   desc="Previous image"  value=-
  AXButton   desc="Next image"      value=-
  AXUnknown  desc="Image 1 of 3"    value=-
```

  The stray per-arrow value is gone and exactly one element carries the position.
- **Contrast measured off rendered pixels** (ImageRenderer at 4x over an L=0.876 image, sampled inside the circle):

| disabled prev arrow | glyph vs scrim | scrim vs image |
|---|---|---|
| before (whole control at 0.35) | 1.26:1 | 1.60:1 |
| after (glyph 0.55, scrim full) | **3.61:1** | **6.17:1** |

## Not covered

The Groups tab has no refresh path on any platform (`GroupService` has no refresh entry point and `GroupListView` has no `.refreshable`), so the Refresh button is scoped to the DMs tab rather than inventing behaviour. Worth its own issue if it should have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
