### PR TITLE
fix(macos): make the Blossom dashboard reachable, and stop it opening as a split view

### DIFF
--- a/HavenApp/HavenApp/Views/Dashboard/BlossomDashboardView.swift
+++ b/HavenApp/HavenApp/Views/Dashboard/BlossomDashboardView.swift
@@ -25,7 +25,10 @@ struct BlossomDashboardView: View {
     @State private var activityLogs: [BlossomActivityLog] = []
 
     var body: some View {
-        NavigationView {
+        // NavigationStack, not the deprecated NavigationView: on macOS the latter
+        // resolves to a split view, so the dashboard opened as an empty sidebar with
+        // its content pushed into a detail pane it never fills.
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
                     // Stats Section

--- a/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryView.swift
+++ b/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryView.swift
@@ -392,6 +392,18 @@ struct MediaGalleryView: View {
                 )
                 .keyboardShortcut("r", modifiers: .command)
 
+                // The Blossom dashboard's only entry points were the iOS-only floating
+                // button, so on macOS four screens of storage, mirror and sync state
+                // compiled, shipped, and could not be opened.
+                IconFilterButton(
+                    icon: "camera.macro",
+                    tooltip: "Blossom Dashboard",
+                    isSelected: true,
+                    color: .havenPurple,
+                    action: { showingBlossomMediaList = true }
+                )
+                .keyboardShortcut("b", modifiers: .command)
+
                 sortMenu
 
                 desktopUploadMenu
@@ -563,6 +575,11 @@ struct MediaGallerySheetsModifier: ViewModifier {
                 BlossomDashboardView()
                     .environmentObject(configService)
                     .environmentObject(nostrService)
+                    #if os(macOS)
+                    // Stats, mirrors, sync and the activity log need room; without a
+                    // minimum the sheet takes the content's ideal size.
+                    .frame(minWidth: 620, minHeight: 640)
+                    #endif
             }
             .fileImporter(
                 isPresented: $showingFileImporter,


### PR DESCRIPTION
Closes `52b1ccdc` — on macOS the Blossom dashboard could not be opened at all.

`BlossomDashboardView` is four sections of storage stats, mirrors, sync state and an activity log. Both buttons that set `showingBlossomMediaList` live inside `#if os(iOS)` branches of `MediaGalleryView`, and that sheet is its only presentation anywhere in the app — so on macOS the view compiled, shipped in the target, and had no entry point.

## Changes

- **Entry point**: a Blossom button (⌘B) in the gallery's desktop header, next to the Refresh added in the pointer/keyboard sweep. No existing shortcut uses ⌘B (`MenuBarView` holds ⌘1–6, ⌘N, ⌘,).
- **Minimum sheet size** on macOS. Stats, mirrors, sync and the log need room, and a macOS sheet with no minimum takes its content's ideal size.
- **`NavigationView` → `NavigationStack`.** The deprecated container resolves to a split view on macOS, so the dashboard opened with its content squeezed into a sidebar next to an empty detail pane.

## Verification

Hosted the same content in an `NSWindow` at 620×400 under each container and captured the real rendered frame (`cacheDisplay`, so `ScrollView` content actually lays out — `ImageRenderer` would not lay it out at all). Measuring the card fill off the pixels:

| container | card width | window |
|---|---|---|
| `NavigationView` (master) | **136 pt**, with an empty detail pane beside it | 620 pt |
| `NavigationStack` (this PR) | **587 pt** | 620 pt |

Both `-scheme HavenApp` and `-scheme HavenApp-iOS` Debug **BUILD SUCCEEDED**. No project file touched.

## Not in scope

`Views/BlossomMediaListView.swift` — 625 lines, zero call sites — is dead code. It belongs to the "delete or wire up the unreachable screens and dead branches" issue (`737b6edb`); deleting it here would mean regenerating the project file in a PR that otherwise doesn't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
