### PR TITLE
fix(macos): quoted notes, parent previews and notification taps open the note

### DIFF
--- a/HavenApp/HavenApp/Views/MenuBarView.swift
+++ b/HavenApp/HavenApp/Views/MenuBarView.swift
@@ -23,6 +23,12 @@ struct MenuBarView: View {
     @State private var showingAccountSwitcher = false
     #if os(macOS)
     @State private var showingCompose = false
+    /// macOS has no navigation stack around the feed and vault, so a
+    /// `NavigationLink(value:)` inside a note row has nothing to push onto and the
+    /// click is swallowed — quoted notes and parent previews did nothing at all.
+    /// Publishing a selection here gives every one of those rows the same single
+    /// path the iPad two-pane layout already uses, resolved to a sheet below.
+    @StateObject private var noteSelection = NoteDetailSelection()
     #endif
 
     @State private var activeHex: String = ConfigService.shared.activeAccountHexPubkey
@@ -872,10 +878,52 @@ struct MenuBarView: View {
             .padding(.top, 4)
         }
         #if os(macOS)
+        .environment(\.noteDetailSelection, noteSelection)
+        .sheet(isPresented: Binding(
+            get: { !noteSelection.isEmpty },
+            set: { if !$0 { noteSelection.clear() } }
+        )) {
+            Group {
+                if let note = noteSelection.note {
+                    NavigationStack {
+                        NoteDetailView(note: note)
+                            .toolbar {
+                                ToolbarItem(placement: .cancellationAction) {
+                                    Button("Done") { noteSelection.clear() }
+                                        .keyboardShortcut(.cancelAction)
+                                }
+                            }
+                    }
+                } else if let noteId = noteSelection.noteId {
+                    NoteDetailViewWrapper(noteId: noteId, onDismiss: { noteSelection.clear() })
+                }
+            }
+            .environmentObject(nostrService)
+            .environmentObject(configService)
+            .frame(minWidth: 560, minHeight: 620)
+        }
         .sheet(isPresented: $showingCompose) {
             ComposeView(onDismiss: { showingCompose = false })
                 .environmentObject(nostrService)
                 .environmentObject(configService)
+        }
+        // Notification taps: LocalNotificationService posts these on both platforms,
+        // but until now only iOS listened, so clicking a zap, reaction or repost
+        // notification on macOS did nothing at all.
+        .onReceive(NotificationCenter.default.publisher(for: .havenOpenRelayLikes)) { _ in
+            selectedTab = .notes
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .havenOpenRelayNotes)) { _ in
+            selectedTab = .notes
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .havenOpenRelayZaps)) { _ in
+            selectedTab = .notes
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .havenOpenMentions)) { notification in
+            selectedTab = .feed
+            if let eventId = notification.object as? String {
+                noteSelection.select(id: eventId)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .composeFromTabBar)) { note in
             // Clear the pending-compose flag before the tab guard, not after.

--- a/HavenApp/HavenApp/Views/Vault/VaultView.swift
+++ b/HavenApp/HavenApp/Views/Vault/VaultView.swift
@@ -750,8 +750,10 @@ struct VaultView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openRelayDashboard)) { _ in
             showingRelayDashboard = true
         }
-        #if os(iOS)
+        // Not iOS-only: this is the macOS body, and gating these meant a notification
+        // tap that reached the Notes tab still showed whatever mode was last open.
         .onReceive(NotificationCenter.default.publisher(for: .havenOpenRelayLikes)) { _ in
+            // In Zaps Only mode the Likes tab is hidden — route to Notes instead.
             let target: ViewMode = configService.config.zapsOnlyMode ? .notes : .likes
             withAnimation(Motion.toggle) { viewMode = target }
         }
@@ -761,7 +763,6 @@ struct VaultView: View {
         .onReceive(NotificationCenter.default.publisher(for: .havenOpenRelayZaps)) { _ in
             withAnimation(Motion.toggle) { viewMode = .zaps }
         }
-        #endif
         .sheet(item: Binding<IdentifiableString?>(
             get: { showingProfilePubkey.map { IdentifiableString(id: $0) } },
             set: { showingProfilePubkey = $0?.id }


### PR DESCRIPTION
Closes `de8d7c2a`.

## Quoted notes and parent previews

`NoteNavigationLink` has two paths: select into a `NoteDetailSelection` when the environment supplies one, else `NavigationLink(value:)`. The only injection site was the iPad two-pane layout (`HavenApp-iOS/ContentView.swift`), and the macOS branch of `FeedView.body` is a plain `VStack` — no `NavigationStack`, no `navigationDestination`. So on macOS the link had nothing to push onto and no destination registered, and the click was swallowed.

`MenuBarView` now publishes a `NoteDetailSelection` on macOS and resolves it to a sheet. Those rows take the **same single path** the iPad layout already uses rather than a third mechanism, which is what the issue asked for. `VaultView.openNote()` rides on it too.

Article cards are unaffected — their selection branch is already `#if os(iOS)`, so macOS keeps its `showingArticle` sheet.

## Notification taps

Second half of the same issue. `LocalNotificationService.navigate` posts `havenOpenRelayLikes` / `havenOpenRelayNotes` / `havenOpenRelayZaps` / `havenOpenMentions` on **both** platforms, but only iOS listened: the receivers in the macOS body of `VaultView` were wrapped in `#if os(iOS)`, and nothing switched tabs. Clicking a zap, reaction or repost notification on macOS did nothing.

- `MenuBarView` routes the three relay notifications to the Notes tab, and `havenOpenMentions` to the feed with the note selected (which is the new selection path doing real work).
- `VaultView`'s mode-switch receivers are no longer `#if os(iOS)` inside the macOS body, so the tab lands on Zaps/Likes/Notes rather than whatever was last open.

## Verification

This is a hit-testing change, so I drove it with synthetic `NSEvent` mouse clicks through the real responder chain rather than reasoning about it — a hosted replica of the selection path with a Button nested inside the card:

```
clicking the card body   -> tap gesture hit -> selection set -> SHEET PRESENTED
clicking the nested Like -> row action fired, no tap gesture, no navigation
```

That second line is the nested-control trap the issue explicitly asked to check: the selection path is a tap gesture rather than a `Button` precisely so a row's own reply/repost/like/zap buttons keep working, and it does.

Both `-scheme HavenApp` and `-scheme HavenApp-iOS` Debug **BUILD SUCCEEDED**. No project file touched.

## Not in this PR

- **DM notification taps on macOS still go nowhere.** `havenOpenDMInbox` is posted by `LocalNotificationService` and handled only in `HavenApp-iOS/ContentView.swift`; wiring it needs the profile tab to open the inbox sheet, which is a different surface. Worth its own issue.
- The narrow-macOS-window behaviour where `.openRelayDashboard` replaces the notes list is unchanged — that comes from a deliberate button in `MenuBarView`, not from a notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
