### PR TITLE
fix(macos,ios): surface the failures that were setting dead state

### DIFF
--- a/HavenApp/HavenApp/Localizable.xcstrings
+++ b/HavenApp/HavenApp/Localizable.xcstrings
@@ -73,6 +73,126 @@
         }
       }
     },
+    "group.browser.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This relay published no groups"
+          }
+        }
+      }
+    },
+    "group.browser.error.noResponse" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The relay did not answer. It may not host groups."
+          }
+        }
+      }
+    },
+    "group.browser.error.unreachable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not reach that relay"
+          }
+        }
+      }
+    },
+    "group.browser.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asking the relay for its groups…"
+          }
+        }
+      }
+    },
+    "group.browser.retry" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try again"
+          }
+        }
+      }
+    },
+    "media.mirror.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not mirror to the local relay"
+          }
+        }
+      }
+    },
+    "media.mirror.saved" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saved to local relay"
+          }
+        }
+      }
+    },
+    "media.paste.error.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clipboard is empty or contains unsupported content"
+          }
+        }
+      }
+    },
+    "media.paste.error.notAURL" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clipboard does not contain a valid URL or image"
+          }
+        }
+      }
+    },
+    "media.push.error.noHash" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This file has no Blossom hash to push"
+          }
+        }
+      }
+    },
+    "media.push.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not push to mirrors"
+          }
+        }
+      }
+    },
+    "media.push.succeeded" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pushed to mirrors"
+          }
+        }
+      }
+    },
     "group.chat.deleteMessage" : {
       "localizations" : {
         "en" : {

--- a/HavenApp/HavenApp/Services/GroupService.swift
+++ b/HavenApp/HavenApp/Services/GroupService.swift
@@ -11,6 +11,18 @@ class GroupService: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var availableGroups: [GroupInfo] = []
 
+    /// Lifecycle of a relay browse. The browser needs to tell "still asking"
+    /// apart from "the relay answered with no groups" and "the relay never
+    /// answered" — an empty list means all three otherwise.
+    enum BrowseState: Equatable {
+        case idle
+        case loading
+        case loaded
+        case failed(String)
+    }
+
+    @Published var browseState: BrowseState = .idle
+
     var totalUnreadCount: Int {
         conversations.reduce(0) { $0 + $1.unreadCount }
     }
@@ -24,6 +36,12 @@ class GroupService: ObservableObject {
     private var groupUpdateSubject = PassthroughSubject<Void, Never>()
     private let processingQueue = DispatchQueue(label: "com.haven.group-processing", qos: .userInitiated)
     private var authenticatedRelays = Set<String>()
+    /// Relay the in-flight browse is addressed to, and a generation counter so a
+    /// late EOSE or timeout from a superseded browse cannot resolve the current one.
+    private var browsingRelay: String?
+    private var browseGeneration: UInt64 = 0
+    /// Generous enough to cover the 2s connect wait plus a slow relay's round trip.
+    private let browseTimeout: TimeInterval = 12
     private var loadedAccountPubkey: String = ""
     private var switchGeneration: UInt64 = 0
 
@@ -89,7 +107,14 @@ class GroupService: ObservableObject {
                             self.subscribeToJoinedGroups(on: urlStr)
                         }
                     }
-                case .disconnected, .error:
+                case .error:
+                    self.authenticatedRelays.remove(urlStr)
+                    // Only a socket-level error fails a browse. `.disconnected`
+                    // also fires on ordinary teardown, including our own.
+                    if urlStr == self.browsingRelay, self.browseState == .loading {
+                        self.browseState = .failed(String(localized: "group.browser.error.unreachable"))
+                    }
+                case .disconnected:
                     self.authenticatedRelays.remove(urlStr)
                 default:
                     break
@@ -169,6 +194,11 @@ class GroupService: ObservableObject {
     }
 
     func browseGroups(on relayURL: String) {
+        browsingRelay = relayURL
+        browseGeneration &+= 1
+        let generation = browseGeneration
+        browseState = .loading
+
         if relayClients[relayURL] == nil {
             connectToRelay(relayURL)
         }
@@ -195,6 +225,15 @@ class GroupService: ObservableObject {
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                 attemptBrowse()
             }
+        }
+
+        // A relay that accepts the socket and never answers the REQ would leave
+        // the browser spinning forever, so fail the browse rather than hang.
+        DispatchQueue.main.asyncAfter(deadline: .now() + browseTimeout) { [weak self] in
+            guard let self = self,
+                  self.browseGeneration == generation,
+                  self.browseState == .loading else { return }
+            self.browseState = .failed(String(localized: "group.browser.error.noResponse"))
         }
     }
 
@@ -234,7 +273,15 @@ class GroupService: ObservableObject {
                     }
                 }
             case "EOSE":
-                DispatchQueue.main.async { self.isLoading = false }
+                let subId = json[safe: 1] as? String
+                DispatchQueue.main.async {
+                    self.isLoading = false
+                    if subId == "grp-browse",
+                       relayURL == self.browsingRelay,
+                       self.browseState == .loading {
+                        self.browseState = .loaded
+                    }
+                }
             default:
                 break
             }

--- a/HavenApp/HavenApp/Views/Components/MediaGridItem.swift
+++ b/HavenApp/HavenApp/Views/Components/MediaGridItem.swift
@@ -15,7 +15,6 @@ struct MediaGridItem: View {
     @State private var showingReportDialog = false
     @State private var isMirroringToLocal = false
     @State private var isPushingToMirrors = false
-    @State private var mirrorStatusMessage: String?
 
     var body: some View {
         Color.clear
@@ -184,7 +183,18 @@ struct MediaGridItem: View {
             let success = await service.downloadFromURL(url: item.url)
             await MainActor.run {
                 isMirroringToLocal = false
-                mirrorStatusMessage = success ? "Saved to local relay" : "Mirror failed"
+                if success {
+                    ActionToastManager.shared.show(
+                        icon: "internaldrive.fill",
+                        message: String(localized: "media.mirror.saved"),
+                        color: Color.havenVerified
+                    )
+                } else {
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.mirror.failed"),
+                        icon: "exclamationmark.icloud.fill"
+                    )
+                }
                 if success {
                     onMirrorComplete?()
                 }
@@ -200,14 +210,29 @@ struct MediaGridItem: View {
             guard sha256.count == 64 && sha256.allSatisfy({ $0.isHexDigit }) else {
                 await MainActor.run {
                     isPushingToMirrors = false
-                    mirrorStatusMessage = "Could not extract hash"
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.push.error.noHash"),
+                        icon: "exclamationmark.icloud.fill",
+                        style: .warning
+                    )
                 }
                 return
             }
             let success = await service.pushLocalToMirrors(sha256: sha256)
             await MainActor.run {
                 isPushingToMirrors = false
-                mirrorStatusMessage = success ? "Pushed to mirrors" : "Push to mirrors failed"
+                if success {
+                    ActionToastManager.shared.show(
+                        icon: "icloud.and.arrow.up.fill",
+                        message: String(localized: "media.push.succeeded"),
+                        color: Color.havenVerified
+                    )
+                } else {
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.push.failed"),
+                        icon: "exclamationmark.icloud.fill"
+                    )
+                }
             }
         }
     }

--- a/HavenApp/HavenApp/Views/Components/MediaListItem.swift
+++ b/HavenApp/HavenApp/Views/Components/MediaListItem.swift
@@ -14,7 +14,6 @@ struct MediaListItem: View {
     @State private var showingReportDialog = false
     @State private var isMirroringToLocal = false
     @State private var isPushingToMirrors = false
-    @State private var mirrorStatusMessage: String?
     @State private var mirroredCount: Int? = nil
     @State private var totalMirrors: Int = 0
 
@@ -256,7 +255,18 @@ struct MediaListItem: View {
             let success = await service.downloadFromURL(url: item.url)
             await MainActor.run {
                 isMirroringToLocal = false
-                mirrorStatusMessage = success ? "Saved to local relay" : "Mirror failed"
+                if success {
+                    ActionToastManager.shared.show(
+                        icon: "internaldrive.fill",
+                        message: String(localized: "media.mirror.saved"),
+                        color: Color.havenVerified
+                    )
+                } else {
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.mirror.failed"),
+                        icon: "exclamationmark.icloud.fill"
+                    )
+                }
                 if success {
                     onMirrorComplete?()
                 }
@@ -272,14 +282,29 @@ struct MediaListItem: View {
             guard sha256.count == 64 && sha256.allSatisfy({ $0.isHexDigit }) else {
                 await MainActor.run {
                     isPushingToMirrors = false
-                    mirrorStatusMessage = "Could not extract hash"
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.push.error.noHash"),
+                        icon: "exclamationmark.icloud.fill",
+                        style: .warning
+                    )
                 }
                 return
             }
             let success = await service.pushLocalToMirrors(sha256: sha256)
             await MainActor.run {
                 isPushingToMirrors = false
-                mirrorStatusMessage = success ? "Pushed to mirrors" : "Push to mirrors failed"
+                if success {
+                    ActionToastManager.shared.show(
+                        icon: "icloud.and.arrow.up.fill",
+                        message: String(localized: "media.push.succeeded"),
+                        color: Color.havenVerified
+                    )
+                } else {
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.push.failed"),
+                        icon: "exclamationmark.icloud.fill"
+                    )
+                }
             }
         }
     }

--- a/HavenApp/HavenApp/Views/GroupBrowserView.swift
+++ b/HavenApp/HavenApp/Views/GroupBrowserView.swift
@@ -7,7 +7,8 @@ struct GroupBrowserView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var relayInput: String = ""
-    @State private var isConnecting = false
+
+    private var isConnecting: Bool { groupService.browseState == .loading }
 
     private var joinedGroupIds: Set<String> {
         Set(configService.config.joinedGroups.map {
@@ -80,19 +81,7 @@ struct GroupBrowserView: View {
 
                 // Group list
                 if groupService.availableGroups.isEmpty {
-                    GeometryReader { geometry in
-                        VStack(spacing: 16) {
-                            Spacer()
-                            Image(systemName: "antenna.radiowaves.left.and.right")
-                                .font(.appSystem(size: 40, weight: .light))
-                                .foregroundColor(.secondary.opacity(0.5))
-                            Text(String(localized: "group.browser.enterRelay"))
-                                .font(.appSystem(size: 14))
-                                .foregroundColor(.secondary)
-                            Spacer()
-                        }
-                        .frame(width: geometry.size.width, height: geometry.size.height)
-                    }
+                    browsePlaceholder
                 } else {
                     List {
                         ForEach(groupService.availableGroups) { info in
@@ -133,18 +122,80 @@ struct GroupBrowserView: View {
         }
     }
 
+    /// Shown whenever there are no rows — which covers four different situations,
+    /// and used to render as one "enter a relay" prompt for all of them.
+    @ViewBuilder
+    private var browsePlaceholder: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 16) {
+                Spacer()
+                switch groupService.browseState {
+                case .idle:
+                    placeholderBody(
+                        icon: "antenna.radiowaves.left.and.right",
+                        message: String(localized: "group.browser.enterRelay")
+                    )
+                case .loading:
+                    ProgressView()
+                        .controlSize(.large)
+                    Text(String(localized: "group.browser.loading"))
+                        .font(.appSystem(size: 14))
+                        .foregroundColor(.secondary)
+                case .loaded:
+                    placeholderBody(
+                        icon: "tray",
+                        message: String(localized: "group.browser.empty")
+                    )
+                case .failed(let message):
+                    // Icon carries the error colour; the message stays at full
+                    // contrast, since red 14pt body text on this surface does not
+                    // clear 4.5:1.
+                    VStack(spacing: 16) {
+                        placeholderBody(
+                            icon: "exclamationmark.triangle.fill",
+                            message: message,
+                            iconTint: .red,
+                            messageTint: .primary
+                        )
+                    }
+                    // Grouped here rather than on the whole placeholder: combining
+                    // the Retry button into the same element would take away its
+                    // button trait and its action.
+                    .accessibilityElement(children: .combine)
+                    Button(String(localized: "group.browser.retry"), action: browse)
+                        .buttonStyle(.borderedProminent)
+                        .tint(.havenPurple)
+                        .disabled(relayInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+                Spacer()
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height)
+        }
+    }
+
+    @ViewBuilder
+    private func placeholderBody(
+        icon: String,
+        message: String,
+        iconTint: Color = .secondary.opacity(0.5),
+        messageTint: Color = .secondary
+    ) -> some View {
+        Image(systemName: icon)
+            .font(.appSystem(size: 40, weight: .light))
+            .foregroundColor(iconTint)
+        Text(message)
+            .font(.appSystem(size: 14))
+            .foregroundColor(messageTint)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 32)
+    }
+
     private func browse() {
         let url = relayInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !url.isEmpty else { return }
 
-        isConnecting = true
         groupService.availableGroups = []
         groupService.browseGroups(on: url)
-
-        // Clear connecting state after a delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            isConnecting = false
-        }
     }
 }
 

--- a/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryUpload.swift
+++ b/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryUpload.swift
@@ -297,8 +297,6 @@ extension MediaGalleryView {
     func handlePasteFromClipboard() {
         // Set loading state immediately
         isPastingContent = true
-        pasteError = nil
-
         Task {
             let blossom = blossomService
             var success = false
@@ -343,7 +341,11 @@ extension MediaGalleryView {
                       url.scheme == "http" || url.scheme == "https" else {
                     await MainActor.run {
                         isPastingContent = false
-                        pasteError = "Clipboard does not contain a valid URL or image"
+                        ErrorNotificationManager.shared.show(
+                            String(localized: "media.paste.error.notAURL"),
+                            icon: "doc.on.clipboard",
+                            style: .warning
+                        )
                     }
                     return
                 }
@@ -363,7 +365,11 @@ extension MediaGalleryView {
                 // Clipboard is empty or unsupported content
                 await MainActor.run {
                     isPastingContent = false
-                    pasteError = "Clipboard is empty or contains unsupported content"
+                    ErrorNotificationManager.shared.show(
+                        String(localized: "media.paste.error.empty"),
+                        icon: "doc.on.clipboard",
+                        style: .warning
+                    )
                 }
                 return
             }

--- a/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryView.swift
+++ b/HavenApp/HavenApp/Views/MediaGallery/MediaGalleryView.swift
@@ -85,7 +85,6 @@ struct MediaGalleryView: View {
     @State var showingUploadOptions = false
     @State var photosPickerFilter: PHPickerFilter = .any(of: [.images, .videos])
     @State var isPastingContent = false
-    @State var pasteError: String?
     @State var activeUploadTasks: [Task<Void, Never>] = []
 
     #if os(iOS)


### PR DESCRIPTION
Closes `cc0ae9aa` — *macOS + iOS: silent failures — Magic Paste, Blossom mirror/push, and a fake Browse spinner*.

Each of the three sites reported failure into a variable with no reader, so a failed action rendered exactly like a no-op.

## Magic Paste

`pasteError` is a `@State` on `MediaGalleryView` written at two sites in `MediaGalleryUpload` and read at zero. Both messages went to `ErrorNotificationManager` instead — it is mounted at the app root on both platforms (`MenuBarView` and iOS `ContentView`), and its pill is styled distinctly from the success toast. The `@State` is gone.

The third paste outcome already worked: a failed upload marks the upload notification failed, which does render.

## Blossom mirror / push

`mirrorStatusMessage` — same defect, four writes and no reads, in `MediaGridItem` **and** in `MediaListItem`, which the issue did not list but has the identical bug. Fixing one and not the other would have made the grid and the list disagree about whether an action reports itself.

Success goes to `ActionToastManager`, which `deleteMediaFromMirrors` already uses for this exact class of action, so mirror/push/delete now report the same way. Failure goes to the error banner.

## Group Browse

The spinner was `asyncAfter(3.0) { isConnecting = false }` — a timer, not a state. It stopped whether or not anything loaded, and an empty list meant four different things at once: "type a relay address", "still asking", "this relay has no groups", "this relay never answered".

`GroupService` now publishes `BrowseState` (`idle`/`loading`/`loaded`/`failed`):

- resolved to `.loaded` by the `grp-browse` EOSE, matched on **both** subscription id and relay URL
- failed by a socket-level error on the browsing relay
- failed by a 12s timeout, so a relay that accepts the socket and never answers the REQ cannot spin forever
- guarded by a generation counter, so a late EOSE or timeout from a superseded browse cannot resolve the current one

`.disconnected` no longer fails a browse — it also fires on ordinary teardown, including ours.

The browser renders one placeholder per state, with a Retry on the error case.

## Accessibility

The error placeholder groups the icon and message into one VoiceOver element but deliberately leaves Retry outside it — combining the button in would have stripped its button trait and its action. The error message stays at full contrast with only the icon tinted red; red 14pt body text on that surface does not clear 4.5:1.

## Verification

- macOS `xcodebuild -scheme HavenApp` — BUILD SUCCEEDED
- iOS `xcodebuild -scheme HavenApp-iOS` — BUILD SUCCEEDED
- New keys confirmed present in the built bundle's `en.lproj/Localizable.strings`
- App launches from the built bundle without crashing

**Not verified live:** I did not drive the four Browse placeholder states in the running UI. The macOS app is a menu-bar extra, and clicking through to the Groups sheet needs accessibility automation I do not have here. The state transitions are reasoned from the code, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
