### PR TITLE
fix(ios,macos): draw long-form articles as articles in the notes feed

### DIFF
--- a/HavenApp/HavenApp/Localizable.xcstrings
+++ b/HavenApp/HavenApp/Localizable.xcstrings
@@ -1694,6 +1694,16 @@
         }
       }
     },
+    "feed.note.longForm" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Article"
+          }
+        }
+      }
+    },
     "feed.share.message" : {
       "localizations" : {
         "en" : {

--- a/HavenApp/HavenApp/Views/ArticleFeedViews.swift
+++ b/HavenApp/HavenApp/Views/ArticleFeedViews.swift
@@ -112,6 +112,85 @@ struct ArticleCardView: View {
     }
 }
 
+// MARK: - Inline body (long-form inside the notes feed)
+
+/// A long-form event drawn inside a normal feed row.
+///
+/// The notes feed carries kinds 1, 6 and 30023, but the row drew every one of
+/// them as `Text(content)` — so an article arrived as its whole markdown body,
+/// unbounded, with `##` and `---` intact and its title (a tag, not body text)
+/// missing entirely.
+///
+/// Deliberately not `ArticleCardView`: the feed row already draws the author,
+/// the timestamp and the action bar, and the card would draw a second author
+/// line inside the first one.
+struct ArticleInlineBody: View {
+    let note: FeedNote
+    /// Focused rows are the note detail's own header row, where the reader is
+    /// what the user came for. In the feed it stays a preview.
+    var isFocused: Bool = false
+    var onImageTap: ((URL) -> Void)? = nil
+
+    private var metadata: LongFormMetadata { note.longFormMetadata }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let imageURL = metadata.imageURL {
+                RetryableAsyncImage(url: imageURL, contentMode: .fill, targetSize: CGSize(width: 800, height: 400))
+                    .frame(height: isFocused ? 180 : 140)
+                    .frame(maxWidth: .infinity)
+                    .clipped()
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+
+            Text(note.longFormDisplayTitle)
+                .font(.appSystem(size: isFocused ? 22 : 18, weight: .bold))
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+                .lineLimit(isFocused ? nil : 3)
+
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.appSystem(size: 10, weight: .semibold))
+                Text(String(localized: "feed.note.longForm"))
+                    .font(.appSystem(size: 11, weight: .semibold))
+                if let minutes = LongFormMetadata.readingTimeMinutes(for: note.content) {
+                    Text("· \(minutes) min read")
+                        .font(.appSystem(size: 11))
+                }
+            }
+            .foregroundColor(.havenPurple)
+            .accessibilityElement(children: .combine)
+
+            if isFocused {
+                if let summary = metadata.summary {
+                    Text(summary)
+                        .font(.appSystem(size: 15))
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Divider()
+                }
+                MarkdownBodyView(markdown: note.content, onImageTap: onImageTap)
+            } else if let preview = previewText, !preview.isEmpty {
+                Text(preview)
+                    .font(.appSystem(size: 15))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(3)
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    /// The author's `summary` tag when they wrote one, otherwise the top of the
+    /// body with markdown syntax stripped — never the raw markdown.
+    private var previewText: String? {
+        if let summary = metadata.summary { return summary }
+        let plain = MarkdownParser.plainText(note.content, limit: 200)
+        return plain.isEmpty ? nil : plain
+    }
+}
+
 // MARK: - Reader
 
 /// Full-body reader for a long-form event.

--- a/HavenApp/HavenApp/Views/FeedView.swift
+++ b/HavenApp/HavenApp/Views/FeedView.swift
@@ -2126,6 +2126,9 @@ struct FeedNoteRow: View {
                     if note.kind == 6 && note.content.isEmpty, let original = rowData.resolvedOriginal {
                         return original.content
                     }
+                    // An article's three compact lines are worth far more spent
+                    // on its title than on the first three lines of markdown.
+                    if note.kind == 30023 { return note.longFormDisplayTitle }
                     return note.content
                 }()
 
@@ -2562,6 +2565,11 @@ struct FeedNoteRow: View {
                     .foregroundColor(.secondary)
             }
             .padding(.top, 4)
+        } else if bodySource.kind == 30023 {
+            // Long-form arrives in the notes feed alongside kinds 1 and 6. Its
+            // title lives in a tag and its body is markdown, so the plain-text
+            // path below drew the whole article raw and untitled.
+            ArticleInlineBody(note: bodySource, isFocused: isFocused)
         } else {
             let formattedContent = NostrContentFormatter.format(bodySource.content, mediaURLs: bodySource.mediaURLs)
             VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
Closes `638119a4` — *iOS: articles not rendering in regular notes feed*.

## What was actually happening

The articles were arriving. The feed subscribes to kinds 1, 6 and 30023, `FeedFilterEngine` does not exclude 30023 outside Articles mode, and the events pass the spam heuristic. They were being **drawn wrong**, not dropped: `FeedNoteRow` sends every kind down one path — `Text(NostrContentFormatter.format(content))` with `lineLimit(nil)`.

A NIP-23 article's title is a tag, not body text, and its body is markdown. So an article rendered untitled, raw, and unbounded.

## Measured, not assumed

150 live kind-30023 events from `relay.damus.io`:

| | |
|---|---|
| `title` tag | 149/150 |
| `published_at` tag | 149/150 |
| `summary` tag | 21/150 |
| `image` tag | 10/150 |
| body length | median 5056 chars, max 14094 |
| bodies containing markdown syntax | 123/150 |

The old row drew a median five-thousand-character unbounded `Text` per article inside a `LazyVStack`, and dropped the one field that names it — present on 99% of articles.

Two design decisions fall straight out of those numbers:

- Only 14% carry a `summary`, so the preview falls back to `MarkdownParser.plainText`, never to raw body text.
- Only 7% carry a hero image, so the layout has to read well with no image at all. It does — the image is conditional.

## The change

`ArticleInlineBody` (new, in `ArticleFeedViews.swift`): hero image if there is one, title, an "Article · N min read" badge in the accent colour, and a preview capped at three lines.

Deliberately **not** `ArticleCardView`. The feed row already draws the author, the timestamp and the action bar; the card draws its own author row and would have nested a second one inside the first.

Focused rows — the note detail's own header row, which is the same `FeedNoteRow` with `isFocused: true` — get the full reader instead: summary, divider, `MarkdownBodyView`. That completes the journey without touching routing: card in the feed, tap, read the article. Reply, zap and repost keep working on it, because it is still a feed row.

Compact mode spends its three lines on the title rather than on the first three lines of markdown.

## One thing I checked and did not change

I suspected `FeedNote.isNoiseOrSpam` was eating articles — its "20 consecutive repeated characters" rule looks exactly like a markdown `--------` rule. Measured it against 120 real articles: it drops 2 of them (one JSON-bodied, one with a genuine character run), and 1 of 120 kind-1 notes. That is not the reported bug, so I left it alone rather than widen the change.

## Verification

- iOS `xcodebuild -scheme HavenApp-iOS` — BUILD SUCCEEDED
- macOS `xcodebuild -scheme HavenApp` — BUILD SUCCEEDED

**Not verified live:** I have not seen this render on device or in the simulator. The layout is reasoned from the measurements above, not observed. Worth one look in the running feed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
