### PR TITLE
fix(android): confirm a swipe-to-delete on a draft

### DIFF
--- a/NostrVault/app/src/main/java/com/nostrvault/ui/screens/DraftsScreen.kt
+++ b/NostrVault/app/src/main/java/com/nostrvault/ui/screens/DraftsScreen.kt
@@ -56,6 +56,13 @@ fun DraftsScreen(
     val selectedIds = remember { mutableStateListOf<String>() }
     var confirmingBulkDelete by remember { mutableStateOf(false) }
 
+    // Id of the draft a swipe is asking to delete, or null. Swiping is a
+    // deliberate gesture, but the thing it destroys is unrecoverable — the same
+    // sentence the bulk dialog already says — and the gesture is one drag away
+    // from the scroll it shares an axis with. So a swipe *asks*, using the same
+    // dialog and the same words as selecting one draft and hitting delete.
+    var confirmingSwipeDelete by remember { mutableStateOf<String?>(null) }
+
     fun exitSelection() {
         isSelecting = false
         selectedIds.clear()
@@ -68,6 +75,24 @@ fun DraftsScreen(
         val live = drafts.map { it.id }.toSet()
         selectedIds.retainAll { it in live }
         if (isSelecting && drafts.isEmpty()) exitSelection()
+    }
+
+    confirmingSwipeDelete?.let { draftId ->
+        AlertDialog(
+            onDismissRequest = { confirmingSwipeDelete = null },
+            title = { Text("Delete this draft?", fontWeight = FontWeight.Bold) },
+            text = { Text("Deleted drafts are removed from your relay and can't be recovered.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteDraft(draftId)
+                    confirmingSwipeDelete = null
+                }) { Text("Delete", color = ErrorRed, fontWeight = FontWeight.Bold) }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmingSwipeDelete = null }) { Text("Cancel") }
+            },
+            containerColor = WindowBackground,
+        )
     }
 
     if (confirmingBulkDelete) {
@@ -219,10 +244,14 @@ fun DraftsScreen(
 
                     val dismissState = rememberSwipeToDismissBoxState(
                         confirmValueChange = { value ->
+                            // Never accept the dismiss: the row springs back and
+                            // the dialog decides. Accepting it here would animate
+                            // the draft away before the user has said yes, and
+                            // there is nothing to animate back if they say no.
                             if (value != SwipeToDismissBoxValue.Settled) {
-                                viewModel.deleteDraft(draft.id)
-                                true
-                            } else false
+                                confirmingSwipeDelete = draft.id
+                            }
+                            false
                         },
                     )
 


### PR DESCRIPTION
Closes `bb11c973`.

That issue listed five defects. **Four of them are already fixed on master** — I checked each in the tree rather than taking the report's word for it:

| Item | State on master |
|---|---|
| Multi-image note crops | Fixed. `MediaCarousel` no longer forces `aspectRatio(4f/3f)` + `ContentScale.Crop`; it takes the first image's ratio and draws every page `Fit`. |
| Feed jumps as images load | Fixed. `SingleMediaPreview` sizes from the `imeta` hint or the aspect cache before the bytes arrive. |
| Card outlined in the accent | Fixed. Unfocused cards get a neutral hairline; the accent is spent on focus. |
| `shadowElevation = 8.dp` | Fixed. 0.dp, with the 2dp focus border carrying the meaning. |

**The fifth was still live, and this PR fixes it.** `DraftsScreen`'s `confirmValueChange` called `deleteDraft` and accepted the dismiss, so one horizontal drag — along the axis the list already scrolls — destroyed a draft with no confirmation and nothing to undo. The bulk-delete path a few lines above already asks, with the sentence *"Deleted drafts are removed from your relay and can't be recovered."*

The swipe now never accepts the dismiss: the row springs back and the same dialog, with the same words as deleting one selected draft, decides. Accepting first would animate the draft away before the user agreed, and leave nothing to animate back when they did not.

The issue also pointed at an inline trash icon in the composer's draft picker. That UI no longer exists — the badge routes to `DraftsScreen` (#27), so this screen is now the only delete surface.

**Verified:** `:app:compileDebugKotlin` exit 0.
**Not verified:** no emulator or handset attached to this machine, so the swipe has not been performed on glass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)